### PR TITLE
Enable hover on highlight in nested Mantine `DataTable`

### DIFF
--- a/app/src/ScatteringCrossSection/CSTable.tsx
+++ b/app/src/ScatteringCrossSection/CSTable.tsx
@@ -18,11 +18,6 @@ const useStyles = createStyles(() => ({
   expandIconRotated: {
     transform: "rotate(90deg)",
   },
-  header: {
-    "& th": {
-      backgroundColor: "white",
-    },
-  },
 }));
 
 interface Props {
@@ -117,9 +112,8 @@ export const CSTable = ({ items }: Props) => {
               withColumnBorders
               withBorder
               borderRadius="md"
-              classNames={{ header: classes.header }}
               sx={{ ".mantine-ScrollArea-viewport": { maxHeight: 300 } }}
-              highlightOnHover={false}
+              highlightOnHover={true}
               columns={[
                 { accessor: "reaction" },
                 {


### PR DESCRIPTION
This did not work previously, but is fixed in the latest `DataTable` version.
Remove the subsequently redundant `header` class.