### PR TITLE
Fix API documentation

### DIFF
--- a/app/src/app/api/scat-css/LTPDocument/openapi.ts
+++ b/app/src/app/api/scat-css/LTPDocument/openapi.ts
@@ -21,7 +21,7 @@ export async function register() {
         content: {
           "application/schema+json": {
             schema: {
-              $ref: LTPDocumentJSONSchema.$schema,
+              $ref: LTPDocumentJSONSchema.$schema?.replace(/^http:/, "https:"),
             },
           },
         },


### PR DESCRIPTION
Redoc does not interpret `http` urls as urls, resulting in an `invalid JSON pointer` error. Ensuring the url is `https` fixes the issue.