### PR TITLE
Add command to separately load organizations

### DIFF
--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -49,6 +49,7 @@
     "drop-database": "tsx src/cli/drop-database.ts",
     "drop-non-user": "tsx src/cli/drop-non-user.ts",
     "reload": "pnpm drop-database && pnpm run setup && pnpm seed seeds/test",
+    "load-orgs": "tsx src/cli/load-orgs.ts",
     "load-css": "tsx src/cli/load-css.ts",
     "format": "dprint fmt",
     "clean": "rm -rf dist",

--- a/packages/database/src/auth/queries.spec.ts
+++ b/packages/database/src/auth/queries.spec.ts
@@ -4,6 +4,7 @@
 
 import { afterAll, beforeAll, describe, expect, it } from "vitest";
 
+import { matchesId } from "../css/queries/testutils.js";
 import { systemDb } from "../system-db.js";
 import { LXCatTestDatabase } from "../testutils.js";
 import { loadTestUserAndOrg, TestKeys } from "./testutils.js";
@@ -14,7 +15,7 @@ describe("given filled ArangoDB container", () => {
 
   beforeAll(async () => {
     db = await LXCatTestDatabase.createTestInstance(systemDb(), "auth-test");
-    testKeys = await loadTestUserAndOrg(db.getDB());
+    testKeys = await loadTestUserAndOrg(db);
 
     return async () => systemDb().dropDatabase("auth-test");
   });
@@ -31,13 +32,13 @@ describe("given filled ArangoDB container", () => {
     expect(result).toEqual([expected]);
   });
 
-  it("should have a single org", async () => {
+  it("should have two organizations", async () => {
     const result = await db.listOrganizations();
-    const expected = {
-      _key: testKeys.testOrgKey,
-      name: "Some organization",
-    };
-    expect(result).toEqual([expected]);
+    const expected = [
+      { _key: testKeys.testOrgKey, name: "Some organization" },
+      { _key: matchesId, name: "Some other organization" },
+    ];
+    expect(result).toEqual(expected);
   });
 
   it("should list organization in users memberships", async () => {

--- a/packages/database/src/auth/testutils.ts
+++ b/packages/database/src/auth/testutils.ts
@@ -2,14 +2,16 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { Database } from "arangojs";
 import testUserCreator from "../test/seed/1_users.js";
+import { LXCatTestDatabase } from "../testutils.js";
 
 export interface TestKeys {
   testUserKey: string;
   testOrgKey: string;
 }
 
-export async function loadTestUserAndOrg(db: Database): Promise<TestKeys> {
+export async function loadTestUserAndOrg(
+  db: LXCatTestDatabase,
+): Promise<TestKeys> {
   return await testUserCreator(db);
 }

--- a/packages/database/src/cli/load-orgs.ts
+++ b/packages/database/src/cli/load-orgs.ts
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: LXCat team
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import "./env.js";
+import { load_organizations_dir } from "../css/loaders.js";
+import { db } from "../db.js";
+
+(async () => {
+  const dir = process.argv[2];
+  await load_organizations_dir(db(), dir);
+})();

--- a/packages/database/src/css/loaders.ts
+++ b/packages/database/src/css/loaders.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { NewLTPDocument } from "@lxcat/schema";
+import { Contributor, NewLTPDocument } from "@lxcat/schema";
 import { readdir, readFile } from "fs/promises";
 import { join } from "path";
 import { LXCatDatabase } from "../lxcat-database.js";
@@ -10,8 +10,8 @@ import { LXCatDatabase } from "../lxcat-database.js";
 async function load_css(db: LXCatDatabase, fn: string) {
   const content = await readFile(fn, { encoding: "utf8" });
   const body = NewLTPDocument.parse(JSON.parse(content));
-  const cs_set_id = await db.createSet(body);
-  console.log(`Inserted ${fn} as ${cs_set_id} into CrossSectionSet collection`);
+  const id = await db.createSet(body);
+  console.log(`Inserted ${fn} as ${id} into CrossSectionSet collection`);
 }
 
 export async function load_css_dir(db: LXCatDatabase, dir: string) {
@@ -23,3 +23,22 @@ export async function load_css_dir(db: LXCatDatabase, dir: string) {
     }
   }
 }
+
+const load_organization_from_file = async (db: LXCatDatabase, path: string) => {
+  const content = await readFile(path, { encoding: "utf8" });
+  const org = Contributor.parse(JSON.parse(content));
+  const orgId = await db.addOrganization(org);
+  console.log(`Inserted organization ${org.name} with key ${orgId}.`);
+};
+
+export const load_organizations_dir = async (
+  db: LXCatDatabase,
+  dir: string,
+) => {
+  const files = await readdir(dir);
+  for (const file of files) {
+    if (file.endsWith(".json")) {
+      await load_organization_from_file(db, join(dir, file));
+    }
+  }
+};

--- a/packages/database/src/test/seed/1_users.ts
+++ b/packages/database/src/test/seed/1_users.ts
@@ -1,14 +1,16 @@
 // SPDX-FileCopyrightText: LXCat team
 
 // SPDX-License-Identifier: AGPL-3.0-or-later
-import "dotenv/config";
-import { Contributor } from "@lxcat/schema";
-import { Database } from "arangojs";
-import { EdgeCollection } from "arangojs/collection.js";
-import { UserWithAccountSessionInDb } from "../../auth/schema.js";
 
-export default async (db: Database) => {
-  const users = db.collection<UserWithAccountSessionInDb>("users");
+import "dotenv/config";
+import { EdgeCollection } from "arangojs/collection.js";
+import { dirname, join } from "path";
+import { UserWithAccountSessionInDb } from "../../auth/schema.js";
+import { load_organizations_dir } from "../../css/loaders.js";
+import { LXCatTestDatabase } from "../index.js";
+
+export default async (db: LXCatTestDatabase) => {
+  const users = db.getDB().collection<UserWithAccountSessionInDb>("users");
   const user = UserWithAccountSessionInDb.parse({
     name: "somename",
     email: "somename@example.com",
@@ -19,26 +21,26 @@ export default async (db: Database) => {
   // TODO hide logs of seed behind a flag
   console.log(`Test user added with _key = ${newUser._key}`);
 
-  const organizations = db.collection<Contributor>("Organization");
-  const organization: Contributor = {
-    name: "Some organization",
-    description: "Description of some organization.",
-    contact: "info@some-org.com",
-    howToReference: "",
-  };
-  const newOrganization = await organizations.save(organization, {
-    returnNew: true,
-  });
-  console.log(`Test organization added with _key = ${newOrganization._key}`);
+  const thisfile = new URL(import.meta.url);
+  await load_organizations_dir(
+    db,
+    join(dirname(thisfile.pathname), "organizations"),
+  );
 
-  const memberships: EdgeCollection = db.collection("MemberOf");
+  const orgId = await db.getOrganizationByName("Some organization");
+
+  if (orgId === undefined) {
+    throw new Error("Could not find test organization: Some organization.");
+  }
+
+  const memberships: EdgeCollection = db.getDB().collection("MemberOf");
   await memberships.save({
     _from: newUser._id,
-    _to: newOrganization._id,
+    _to: orgId,
   });
-  console.log("Test user member of test organization");
+
   return {
     testUserKey: newUser._key,
-    testOrgKey: newOrganization._key,
+    testOrgKey: orgId.split("/")[1],
   };
 };

--- a/packages/database/src/test/seed/organizations/dummy.json
+++ b/packages/database/src/test/seed/organizations/dummy.json
@@ -1,0 +1,6 @@
+{
+  "name": "Some organization",
+  "description": "Description of some organization.",
+  "contact": "info@some-org.com",
+  "howToReference": ""
+}

--- a/packages/database/src/test/seed/organizations/dummy.json.license
+++ b/packages/database/src/test/seed/organizations/dummy.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: LXCat team
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/packages/database/src/test/seed/organizations/dummy2.json
+++ b/packages/database/src/test/seed/organizations/dummy2.json
@@ -1,0 +1,6 @@
+{
+  "name": "Some other organization",
+  "description": "Test description",
+  "contact": "org@email.com",
+  "howToReference": "Test reference"
+}

--- a/packages/database/src/test/seed/organizations/dummy2.json.license
+++ b/packages/database/src/test/seed/organizations/dummy2.json.license
@@ -1,0 +1,3 @@
+SPDX-FileCopyrightText: LXCat team
+
+SPDX-License-Identifier: AGPL-3.0-or-later

--- a/packages/database/src/testutils.ts
+++ b/packages/database/src/testutils.ts
@@ -57,13 +57,7 @@ export class LXCatTestDatabase extends LXCatDatabase {
   }
 
   public async setupTestUser() {
-    const testKeys = await loadTestUserAndOrg(this.db);
-    await this.addOrganization({
-      name: "Some other organization",
-      description: "Test description",
-      contact: "org@email.com",
-      howToReference: "Test reference",
-    });
+    const testKeys = await loadTestUserAndOrg(this);
     return this.toggleRole(testKeys.testUserKey, "author");
   }
 


### PR DESCRIPTION
Add a `load-orgs` command to the `@lxcat/database` packages. This command is used to load a directory of
organization definitions. Previously, upon adding a dataset using `load-css`, the organization was automatically created if it did not exist. This is undesired behavior, which has been fixed in #872. However, as a result a method is required to load organizations separately, hence this pr.