### PR TITLE
Add support for triatomic molecules with the `C2v` symmetry

### DIFF
--- a/packages/schema/src/species/molecules/any-molecule.ts
+++ b/packages/schema/src/species/molecules/any-molecule.ts
@@ -5,12 +5,14 @@
 import { discriminatedUnion, output } from "zod";
 import { HeteronuclearDiatom } from "./diatom-heteronuclear.js";
 import { HomonuclearDiatom } from "./diatom-homonuclear.js";
+import { TriatomC2v } from "./triatom-c2v.js";
 import { LinearTriatomInversionCenter } from "./triatom-linear-inversion-center.js";
 
 export const AnyMolecule = discriminatedUnion("type", [
   HomonuclearDiatom.plain,
   HeteronuclearDiatom.plain,
   LinearTriatomInversionCenter.plain,
+  TriatomC2v.plain,
 ]);
 export type AnyMolecule = output<typeof AnyMolecule>;
 
@@ -18,5 +20,6 @@ export const AnyMoleculeSerializable = discriminatedUnion("type", [
   HomonuclearDiatom.serializable,
   HeteronuclearDiatom.serializable,
   LinearTriatomInversionCenter.serializable,
+  TriatomC2v.serializable,
 ]);
 export type AnyMoleculeSerializable = output<typeof AnyMoleculeSerializable>;

--- a/packages/schema/src/species/molecules/components/electronic/spectroscopic.ts
+++ b/packages/schema/src/species/molecules/components/electronic/spectroscopic.ts
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: LXCat team
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { object, string } from "zod";
+import { makeComponent } from "../../../component.js";
+
+const SpectroscopicElectronicDescriptor = object({
+  energyId: string().min(1),
+});
+
+export const SpectroscopicElectronic = makeComponent(
+  SpectroscopicElectronicDescriptor,
+  (desc) => desc.energyId,
+  (desc) => `\\mathrm{${desc.energyId}}`,
+);

--- a/packages/schema/src/species/molecules/components/rotational/array.ts
+++ b/packages/schema/src/species/molecules/components/rotational/array.ts
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: LXCat team
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { array, number, object } from "zod";
+import { makeComponent } from "../../../component.js";
+
+const RotationalArrayDescriptor = (size: number) =>
+  object({
+    J: array(number().nonnegative().int()).length(size),
+  });
+
+export const RotationalArray = (size: number) =>
+  makeComponent(
+    RotationalArrayDescriptor(size),
+    (rot) => rot.J.join(","),
+    (rot) => rot.J.join(","),
+  );

--- a/packages/schema/src/species/molecules/components/rotational/array.ts
+++ b/packages/schema/src/species/molecules/components/rotational/array.ts
@@ -13,6 +13,6 @@ const RotationalArrayDescriptor = (size: number) =>
 export const RotationalArray = (size: number) =>
   makeComponent(
     RotationalArrayDescriptor(size),
-    (rot) => rot.J.join(","),
-    (rot) => rot.J.join(","),
+    (rot) => rot.J.join(""),
+    (rot) => rot.J.join(""),
   );

--- a/packages/schema/src/species/molecules/components/rotational/single.ts
+++ b/packages/schema/src/species/molecules/components/rotational/single.ts
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { number, object } from "zod";
-import { makeComponent } from "../../component.js";
+import { makeComponent } from "../../../component.js";
 
 const RotationalDescriptor = object({ J: number().int() });
 

--- a/packages/schema/src/species/molecules/diatom-heteronuclear.ts
+++ b/packages/schema/src/species/molecules/diatom-heteronuclear.ts
@@ -6,7 +6,7 @@ import { z } from "zod";
 import { SimpleParticle } from "../composition/simple/particle.js";
 import { makeMolecule } from "../generators.js";
 import { LinearElectronic } from "./components/electronic/linear.js";
-import { Rotational } from "./components/rotational.js";
+import { Rotational } from "./components/rotational/single.js";
 import { DiatomicVibrational } from "./components/vibrational/diatomic.js";
 
 export const HeteronuclearDiatom = makeMolecule(

--- a/packages/schema/src/species/molecules/diatom-homonuclear.ts
+++ b/packages/schema/src/species/molecules/diatom-homonuclear.ts
@@ -6,7 +6,7 @@ import { z } from "zod";
 import { SimpleParticle } from "../composition/simple/particle.js";
 import { makeMolecule } from "../generators.js";
 import { LinearInversionCenterElectronic } from "./components/electronic/linear-inversion-center.js";
-import { Rotational } from "./components/rotational.js";
+import { Rotational } from "./components/rotational/single.js";
 import { DiatomicVibrational } from "./components/vibrational/diatomic.js";
 
 export const HomonuclearDiatom = makeMolecule(

--- a/packages/schema/src/species/molecules/triatom-c2v.ts
+++ b/packages/schema/src/species/molecules/triatom-c2v.ts
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: LXCat team
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { SimpleParticle } from "../composition/simple/particle.js";
+import { makeMolecule } from "../generators.js";
+import { SpectroscopicElectronic } from "./components/electronic/spectroscopic.js";
+import { RotationalArray } from "./components/rotational/array.js";
+import { LinearTriatomVibrational } from "./components/vibrational/linear-triatomic.js";
+
+export const TriatomC2v = makeMolecule(
+  "TriatomC2v",
+  SimpleParticle,
+  SpectroscopicElectronic,
+  LinearTriatomVibrational,
+  RotationalArray(3),
+);

--- a/packages/schema/src/species/molecules/triatom-linear-inversion-center.ts
+++ b/packages/schema/src/species/molecules/triatom-linear-inversion-center.ts
@@ -6,7 +6,7 @@ import { z } from "zod";
 import { SimpleParticle } from "../composition/simple/particle.js";
 import { makeMolecule } from "../generators.js";
 import { LinearInversionCenterElectronic } from "./components/electronic/linear-inversion-center.js";
-import { Rotational } from "./components/rotational.js";
+import { Rotational } from "./components/rotational/single.js";
 import { LinearTriatomVibrational } from "./components/vibrational/linear-triatomic.js";
 
 export const LinearTriatomInversionCenter = makeMolecule(

--- a/packages/schema/src/species/species.test.ts
+++ b/packages/schema/src/species/species.test.ts
@@ -339,6 +339,42 @@ describe("State serialization", () => {
         summary: "CO2{X^1S_g^+{000|050|210|130|021|101}}",
       },
     ],
+    [
+      "H2O rotational",
+      {
+        particle: "H2O",
+        charge: 0,
+        type: "TriatomC2v",
+        electronic: {
+          energyId: "X",
+          vibrational: {
+            v: [0, 0, 0],
+            rotational: {
+              J: [0, 0, 0],
+            },
+          },
+        },
+      },
+      {
+        particle: "H2O",
+        charge: 0,
+        summary: "H2O{X{000{000}}}",
+        latex:
+          "\\mathrm{H2O}\\left(\\mathrm{X}\\left(000\\left(000\\right)\\right)\\right)",
+        electronic: {
+          summary: "X",
+          latex: "\\mathrm{X}",
+          vibrational: {
+            summary: "000",
+            latex: "000",
+            rotational: {
+              summary: "000",
+              latex: "000",
+            },
+          },
+        },
+      },
+    ],
   ];
 
   it.each(testCases)("%s", (_, input, summary) => {

--- a/packages/schema/src/test-data/LTPMixture.schema.json
+++ b/packages/schema/src/test-data/LTPMixture.schema.json
@@ -1000,6 +1000,9 @@
           "$ref": "#/definitions/LinearTriatomInversionCenter"
         },
         {
+          "$ref": "#/definitions/TriatomC2v"
+        },
+        {
           "$ref": "#/definitions/unspecified"
         }
       ]
@@ -1914,6 +1917,162 @@
               "type": "array",
               "items": {
                 "$ref": "#/definitions/HomonuclearDiatom/properties/electronic/anyOf/0/allOf/0"
+              },
+              "minItems": 2,
+              "description": "Compound"
+            }
+          ]
+        }
+      },
+      "required": [
+        "type",
+        "particle",
+        "charge",
+        "electronic"
+      ],
+      "additionalProperties": false
+    },
+    "TriatomC2v": {
+      "type": "object",
+      "properties": {
+        "type": {
+          "type": "string",
+          "const": "TriatomC2v"
+        },
+        "particle": {
+          "$ref": "#/definitions/simple/properties/particle"
+        },
+        "charge": {
+          "$ref": "#/definitions/simple/properties/charge"
+        },
+        "electronic": {
+          "anyOf": [
+            {
+              "allOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "energyId": {
+                      "type": "string",
+                      "minLength": 1
+                    }
+                  },
+                  "required": [
+                    "energyId"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "vibrational": {
+                      "anyOf": [
+                        {
+                          "allOf": [
+                            {
+                              "$ref": "#/definitions/LinearTriatomInversionCenter/properties/electronic/anyOf/0/allOf/1/properties/vibrational/anyOf/0/allOf/0"
+                            },
+                            {
+                              "type": "object",
+                              "properties": {
+                                "rotational": {
+                                  "anyOf": [
+                                    {
+                                      "type": "object",
+                                      "properties": {
+                                        "J": {
+                                          "type": "array",
+                                          "items": {
+                                            "type": "integer",
+                                            "minimum": 0
+                                          },
+                                          "minItems": 3,
+                                          "maxItems": 3
+                                        }
+                                      },
+                                      "required": [
+                                        "J"
+                                      ],
+                                      "additionalProperties": false,
+                                      "description": "Singular"
+                                    },
+                                    {
+                                      "type": "array",
+                                      "items": {
+                                        "anyOf": [
+                                          {
+                                            "type": "object",
+                                            "properties": {
+                                              "J": {
+                                                "$ref": "#/definitions/TriatomC2v/properties/electronic/anyOf/0/allOf/1/properties/vibrational/anyOf/0/allOf/1/properties/rotational/anyOf/0/properties/J"
+                                              }
+                                            },
+                                            "required": [
+                                              "J"
+                                            ],
+                                            "additionalProperties": false,
+                                            "description": "Singular"
+                                          },
+                                          {
+                                            "type": "string",
+                                            "description": "Unspecified"
+                                          }
+                                        ]
+                                      },
+                                      "minItems": 2,
+                                      "description": "Compound"
+                                    },
+                                    {
+                                      "type": "string",
+                                      "description": "Unspecified"
+                                    }
+                                  ]
+                                }
+                              }
+                            }
+                          ],
+                          "description": "Singular"
+                        },
+                        {
+                          "type": "array",
+                          "items": {
+                            "anyOf": [
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "v": {
+                                    "$ref": "#/definitions/LinearTriatomInversionCenter/properties/electronic/anyOf/0/allOf/1/properties/vibrational/anyOf/0/allOf/0/properties/v"
+                                  }
+                                },
+                                "required": [
+                                  "v"
+                                ],
+                                "additionalProperties": false,
+                                "description": "Singular"
+                              },
+                              {
+                                "type": "string",
+                                "description": "Unspecified"
+                              }
+                            ]
+                          },
+                          "minItems": 2,
+                          "description": "Compound"
+                        },
+                        {
+                          "type": "string",
+                          "description": "Unspecified"
+                        }
+                      ]
+                    }
+                  }
+                }
+              ],
+              "description": "Singular"
+            },
+            {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/TriatomC2v/properties/electronic/anyOf/0/allOf/0"
               },
               "minItems": 2,
               "description": "Compound"


### PR DESCRIPTION
Adds the `TriatomC2v` type that can be used to define excited states of triatomic molecules that adhere to the $C_{2v}$ symmetry group (e.g. $\\mathrm{H}_2 \\mathrm{O}$).