### PR TITLE
Fix `/api-doc` page in production

### DIFF
--- a/app/src/app/api-doc/page.tsx
+++ b/app/src/app/api-doc/page.tsx
@@ -6,7 +6,7 @@
 import { RedocStandalone } from "redoc";
 
 export default function IndexPage() {
-  const url = `${process.env.NEXT_PUBLIC_URL}/api/doc/`;
+  const url = "/api/doc/";
   return (
     <section className="container">
       <RedocStandalone specUrl={url} />


### PR DESCRIPTION
By using a relative path to `/api/doc`.