### PR TITLE
Add `convert` command for `@lxcat/converter` package

### DIFF
--- a/packages/converter/package.json
+++ b/packages/converter/package.json
@@ -17,6 +17,7 @@
     "dev": "pnpm build",
     "build": "napi build --release --strip --dts dist/index.d.ts",
     "build:debug": "napi build --dts dist/index.d.ts",
+    "convert": "tsx util/convert.ts",
     "test": "tsx --test tests/valid.test.ts",
     "annotate": "reuse annotate --license=Apache-2.0 --copyright='LXCat team' -r --skip-existing --exclude-year --skip-unrecognised src tests",
     "clean": "rm -rf target dist",

--- a/packages/converter/util/convert.ts
+++ b/packages/converter/util/convert.ts
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: LXCat team
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { readFileSync } from "fs";
+import { convertDocument } from "..";
+
+if (process.argv.length !== 3) {
+  throw new Error(
+    "Expected the path to the JSON file to convert to legacy format as the only argument.",
+  );
+}
+
+const file = readFileSync(process.argv[2], "utf8");
+
+console.log(convertDocument(JSON.parse(file)));


### PR DESCRIPTION
This command can be issued to convert a LXCat JSON document to the legacy format on the command line.