### PR TITLE
Fix the API documentation page

### DIFF
--- a/app/e2e/api-doc.spec.ts
+++ b/app/e2e/api-doc.spec.ts
@@ -1,0 +1,13 @@
+// SPDX-FileCopyrightText: LXCat team
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { expect, test } from "@playwright/test";
+
+test.use({ storageState: "adminStorageState.json" });
+
+test("/api-doc", async ({ page }) => {
+  await page.goto("/api-doc");
+  const h1 = page.locator("h1");
+  await expect(h1).toContainText("LXCat API");
+});

--- a/app/src/app/api-doc/page-client.tsx
+++ b/app/src/app/api-doc/page-client.tsx
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: LXCat team
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+"use client";
+
+import { RedocStandalone } from "redoc";
+
+export function DocsPageClient({ spec }: { spec: any }) {
+  const url = "/api/doc/";
+  return (
+    <section className="container">
+      <RedocStandalone spec={spec} />
+    </section>
+  );
+}

--- a/app/src/app/api-doc/page.tsx
+++ b/app/src/app/api-doc/page.tsx
@@ -2,14 +2,10 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-"use client";
-import { RedocStandalone } from "redoc";
+import { generateOpenAPI } from "@/docs/openapi";
+import { DocsPageClient } from "./page-client";
 
-export default function IndexPage() {
-  const url = "/api/doc/";
-  return (
-    <section className="container">
-      <RedocStandalone specUrl={url} />
-    </section>
-  );
+export default async function DocsPage() {
+  const spec = await generateOpenAPI();
+  return <DocsPageClient spec={spec} />;
 }

--- a/app/src/app/api/author/scat-css/[id]/openapi.ts
+++ b/app/src/app/api/author/scat-css/[id]/openapi.ts
@@ -5,7 +5,7 @@
 import { extendZodWithOpenApi } from "@asteasolutions/zod-to-openapi";
 import { z } from "zod";
 import { registry, requestParamsFromSchema } from "../../../../../docs/openapi";
-import { deleteSchema, postSchema } from "./route";
+import { deleteSchema, postSchema } from "./schemas";
 
 export async function register() {
   extendZodWithOpenApi(z);

--- a/app/src/app/api/author/scat-css/[id]/route.ts
+++ b/app/src/app/api/author/scat-css/[id]/route.ts
@@ -2,10 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { LXCatID } from "@/shared/lxcatid";
 import { db } from "@lxcat/database";
-import { EditedLTPDocument } from "@lxcat/schema";
-import { object, string } from "zod";
 import {
   badRequestResponse,
   forbiddenResponse,
@@ -16,16 +13,7 @@ import {
 import { hasAuthorRole, hasSessionOrAPIToken } from "../../../middleware/auth";
 import { zodMiddleware } from "../../../middleware/zod";
 import { RouteBuilder } from "../../../route-builder";
-
-export const postSchema = object({
-  path: object({ id: LXCatID }),
-  body: object({ doc: EditedLTPDocument, message: string().min(1) }),
-});
-
-export const deleteSchema = object({
-  path: object({ id: LXCatID }),
-  body: object({ message: string().min(1) }),
-});
+import { deleteSchema, postSchema } from "./schemas";
 
 const postRouter = RouteBuilder
   .init()

--- a/app/src/app/api/author/scat-css/[id]/schemas.ts
+++ b/app/src/app/api/author/scat-css/[id]/schemas.ts
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: LXCat team
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { LXCatID } from "@/shared/lxcatid";
+import { EditedLTPDocument } from "@lxcat/schema";
+import { object, string } from "zod";
+
+export const postSchema = object({
+  path: object({ id: LXCatID }),
+  body: object({ doc: EditedLTPDocument, message: string().min(1) }),
+});
+
+export const deleteSchema = object({
+  path: object({ id: LXCatID }),
+  body: object({ message: string().min(1) }),
+});

--- a/app/src/app/api/schemas.openapi.ts
+++ b/app/src/app/api/schemas.openapi.ts
@@ -9,6 +9,7 @@ import { Reference, VersionedLTPDocumentWithReference } from "@lxcat/schema";
 import { Reaction, ReactionTypeTag } from "@lxcat/schema/process";
 import {
   AnySpecies,
+  Composition,
   SerializedSpecies,
   StateSummary,
 } from "@lxcat/schema/species";
@@ -122,6 +123,10 @@ export const reactionQuerySchema = z.object({
 });
 
 export async function register() {
+  (Composition._def as any).type._def.items[0].options[1]._def.openapi = {
+    _internal: { refId: "Composition" },
+    metadata: { type: "object" },
+  };
   AnySpecies._def.openapi = { _internal: { refId: "AnySpecies" } };
   VersionedLTPDocumentWithReference._def.openapi = {
     _internal: { refId: "VersionedLTPDocumentWithReference" },

--- a/app/src/shared/header/nav-bar.module.css
+++ b/app/src/shared/header/nav-bar.module.css
@@ -7,7 +7,7 @@
 .header {
   position: sticky;
   top: 0;
-  z-index: 1;
+  z-index: 2;
   height: rem(60px);
   background-color: light-dark(var(--mantine-color-brand-5), var(--mantine-color-brand-7));
   border-bottom: rem(1px) solid light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));


### PR DESCRIPTION
Adds the necessary openapi annotations to the recursive `Composition` type, and fixes some styling issues. Also adds an end-to-end test to check whether the `/api-doc` page is successfully rendered.