### PR TITLE
Improve missing state/reference key errors in document types

### DIFF
--- a/packages/schema/src/document.test.ts
+++ b/packages/schema/src/document.test.ts
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { describe, expect, test } from "vitest";
+import { ZodError, ZodIssueCode } from "zod";
 import { EditedLTPDocument } from "./edited-document.js";
 import { NewLTPDocument } from "./new-document.js";
 import { VersionedLTPDocument } from "./versioned-document.js";
@@ -39,7 +40,14 @@ describe("LTPDocument", () => {
       ],
     };
     expect(() => NewLTPDocument.parse(doc)).toThrowError(
-      "Referenced state key is missing in states record.",
+      new ZodError([
+        {
+          code: ZodIssueCode.custom,
+          message:
+            "Referenced state key (FaultyKey) is missing in the states record.",
+          path: [],
+        },
+      ]),
     );
   });
   test("Should throw when referencing faulty reference key", () => {
@@ -73,7 +81,14 @@ describe("LTPDocument", () => {
       ],
     };
     expect(() => NewLTPDocument.parse(doc)).toThrowError(
-      "Referenced reference key is missing in references record.",
+      new ZodError([
+        {
+          code: ZodIssueCode.custom,
+          message:
+            "Referenced reference key (FaultyKey) is missing in the references record.",
+          path: [],
+        },
+      ]),
     );
   });
   test("An edited document can contain both new and existing processes", () => {

--- a/packages/schema/src/edited-document.ts
+++ b/packages/schema/src/edited-document.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { array, object, record, string, TypeOf } from "zod";
+import { array, object, record, string, TypeOf, ZodIssueCode } from "zod";
 import { Reference, ReferenceRef } from "./common/reference.js";
 import { partialKeyed } from "./partial-keyed.js";
 import { EditedProcess } from "./process/edited-process.js";
@@ -22,27 +22,42 @@ const EditedDocumentBody = object({
 export const EditedLTPDocument = partialKeyed(
   EditedDocumentBody.merge(SetHeader(string().min(1))),
 )
-  .refine(
-    (doc) =>
-      doc.processes
-        .flatMap((process) => process.reaction.lhs)
-        .every(({ state }) => state in doc.states)
-      && doc.processes
-        .flatMap((process) => process.reaction.rhs)
-        .every(({ state }) => state in doc.states),
-    "Referenced state key is missing in states record.",
-  )
-  .refine(
-    (doc) =>
-      doc.processes
-        .flatMap(({ info }) => info)
-        .flatMap(({ references }) => references)
-        .every((reference) =>
-          typeof reference === "string"
-            ? reference in doc.references
-            : reference.id in doc.references
-        ),
-    "Referenced reference key is missing in references record.",
+  .superRefine((doc, ctx) => {
+    const checkState = (key: string) => {
+      const valid = key in doc.states;
+
+      if (!valid) {
+        ctx.addIssue({
+          code: ZodIssueCode.custom,
+          message:
+            `Referenced state key (${key}) is missing in the states record.`,
+        });
+      }
+    };
+
+    doc.processes
+      .flatMap((process) => process.reaction.lhs)
+      .forEach(({ state }) => checkState(state));
+    doc.processes
+      .flatMap((process) => process.reaction.rhs)
+      .every(({ state }) => checkState(state));
+  })
+  .superRefine((doc, ctx) =>
+    doc.processes
+      .flatMap(({ info }) => info)
+      .flatMap(({ references }) => references)
+      .forEach((reference) => {
+        const key = typeof reference === "string" ? reference : reference.id;
+        const valid = key in doc.references;
+
+        if (!valid) {
+          ctx.addIssue({
+            code: ZodIssueCode.custom,
+            message:
+              `Referenced reference key (${key}) is missing in the references record.`,
+          });
+        }
+      })
   );
 
 export type EditedLTPDocument = TypeOf<typeof EditedLTPDocument>;


### PR DESCRIPTION
Uses `zod`s `superRefine` to detect key errors instead of `refine`.