### PR TITLE
Add list of contributors to homepage

### DIFF
--- a/app/src/app/contributor-table.module.css
+++ b/app/src/app/contributor-table.module.css
@@ -8,3 +8,18 @@
   padding: 10px;
   background: light-dark(var(--mantine-color-gray-0), var(--mantine-color-gray-8));
 }
+
+.icon {
+  width: rem(13px);
+  height: auto;
+  vertical-align: rem(-1px);
+  margin-right: rem(8px);
+}
+
+.expandIcon {
+  transition: transform 0.2s;
+}
+
+.expandIconRotated {
+  transform: rotate(90deg);
+}

--- a/app/src/app/contributor-table.module.css
+++ b/app/src/app/contributor-table.module.css
@@ -1,0 +1,10 @@
+/*
+ * SPDX-FileCopyrightText: LXCat team
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+.nested {
+  padding: 10px;
+  background: light-dark(var(--mantine-color-gray-0), var(--mantine-color-gray-8));
+}

--- a/app/src/app/contributor-table.tsx
+++ b/app/src/app/contributor-table.tsx
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: LXCat team
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+"use client";
+
+import { Contributor } from "@lxcat/schema";
+import { ActionIcon, Box, Center, Text } from "@mantine/core";
+import { DataTable } from "mantine-datatable";
+import Link from "next/link";
+import { useState } from "react";
+
+import { IconExternalLink } from "@tabler/icons-react";
+import classes from "./contributor-table.module.css";
+
+export const ContributorTable = (
+  { contributors }: { contributors: Array<Contributor> },
+) => {
+  const [expanded, setExpanded] = useState<Array<string>>([]);
+
+  return (
+    <DataTable
+      withTableBorder
+      height={600}
+      borderRadius="sm"
+      records={contributors}
+      idAccessor="name"
+      columns={[
+        { accessor: "name" },
+        { accessor: "contact" },
+        {
+          accessor: "link",
+          title: "LXCat 2 link",
+          render: ({ name }) => (
+            <Center>
+              <Link
+                href={`https://lxcat.net/${name}`}
+                passHref
+                legacyBehavior
+              >
+                <ActionIcon
+                  component="a"
+                  target="_blank"
+                  size="sm"
+                  variant="subtle"
+                  onClick={(event) => event.stopPropagation()}
+                >
+                  <IconExternalLink />
+                </ActionIcon>
+              </Link>
+            </Center>
+          ),
+        },
+      ]}
+      rowExpansion={{
+        allowMultiple: true,
+        expanded: { recordIds: expanded, onRecordIdsChange: setExpanded },
+        content: ({ record }) => (
+          <Box className={classes.nested}>
+            <Text fw={700}>How to reference:</Text>
+            <Text>{record.howToReference}</Text>
+            <Text fw={700}>Description:</Text>
+            <Text>{record.description}</Text>
+          </Box>
+        ),
+      }}
+    />
+  );
+};

--- a/app/src/app/contributor-table.tsx
+++ b/app/src/app/contributor-table.tsx
@@ -10,7 +10,8 @@ import { DataTable } from "mantine-datatable";
 import Link from "next/link";
 import { useState } from "react";
 
-import { IconExternalLink } from "@tabler/icons-react";
+import { IconChevronRight, IconExternalLink } from "@tabler/icons-react";
+import clsx from "clsx";
 import classes from "./contributor-table.module.css";
 
 export const ContributorTable = (
@@ -26,7 +27,20 @@ export const ContributorTable = (
       records={contributors}
       idAccessor="name"
       columns={[
-        { accessor: "name" },
+        {
+          accessor: "name",
+          width: 180,
+          render: ({ name }) => (
+            <>
+              <IconChevronRight
+                className={clsx(classes.icon, classes.expandIcon, {
+                  [classes.expandIconRotated]: expanded.includes(name),
+                })}
+              />
+              <span>{name}</span>
+            </>
+          ),
+        },
         { accessor: "contact" },
         {
           accessor: "link",

--- a/app/src/app/contributor-table.tsx
+++ b/app/src/app/contributor-table.tsx
@@ -4,7 +4,6 @@
 
 "use client";
 
-import { Contributor } from "@lxcat/schema";
 import { ActionIcon, Box, Center, Text } from "@mantine/core";
 import { DataTable } from "mantine-datatable";
 import Link from "next/link";
@@ -12,10 +11,11 @@ import { useState } from "react";
 
 import { IconChevronRight, IconExternalLink } from "@tabler/icons-react";
 import clsx from "clsx";
+import { ContributorWithStats } from "../../../packages/database/dist/auth/queries";
 import classes from "./contributor-table.module.css";
 
 export const ContributorTable = (
-  { contributors }: { contributors: Array<Contributor> },
+  { contributors }: { contributors: Array<ContributorWithStats> },
 ) => {
   const [expanded, setExpanded] = useState<Array<string>>([]);
 
@@ -42,6 +42,7 @@ export const ContributorTable = (
           ),
         },
         { accessor: "contact" },
+        { accessor: "nSets", title: "# converted sets", textAlign: "center" },
         {
           accessor: "link",
           title: "LXCat 2 link",

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -53,4 +53,6 @@ const Home = async () => {
   );
 };
 
+export const dynamic = "force-dynamic";
+
 export default Home;

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -5,8 +5,11 @@
 import { jsonLdScriptProps } from "react-schemaorg";
 import { Organization, WebSite, WithContext } from "schema-dts";
 
+import { db } from "@lxcat/database";
+import { Fieldset, Text, Title } from "@mantine/core";
 import Script from "next/script";
 import logo from "../../public/lxcat.png";
+import { ContributorTable } from "./contributor-table";
 
 const jsonLDLogo: WithContext<Organization> = {
   "@context": "https://schema.org",
@@ -25,18 +28,29 @@ const jsonLDWebsite: WithContext<WebSite> = {
   },
 };
 
-const Home = () => (
-  <>
-    <Script key="jsonld-logo" {...jsonLdScriptProps(jsonLDLogo)} />
-    <Script key="jsonld-website" {...jsonLdScriptProps(jsonLDWebsite)} />
+const Home = async () => {
+  const contributors = await db().listContributors();
 
-    <h1>Welcome to LXCat</h1>
+  return (
+    <>
+      <Script key="jsonld-logo" {...jsonLdScriptProps(jsonLDLogo)} />
+      <Script key="jsonld-website" {...jsonLdScriptProps(jsonLDWebsite)} />
 
-    <p>
-      This is the next version of the LXCat web site and is under heavy
-      construction.
-    </p>
-  </>
-);
+      <Title order={1} style={{ margin: 10 }}>Welcome to LXCat!</Title>
+
+      <Text style={{ margin: 10 }}>
+        This is the next version of the LXCat web site and is under heavy
+        construction.
+      </Text>
+
+      <Fieldset>
+        <Title order={2} style={{ marginLeft: 10, marginBottom: 10 }}>
+          List of data contributors
+        </Title>
+        <ContributorTable contributors={contributors} />
+      </Fieldset>
+    </>
+  );
+};
 
 export default Home;

--- a/packages/database/src/auth/queries.ts
+++ b/packages/database/src/auth/queries.ts
@@ -206,6 +206,14 @@ export async function listUsers(this: LXCatDatabase) {
   return await cursor.all();
 }
 
+export async function listContributors(this: LXCatDatabase) {
+  const cursor: ArrayCursor<Contributor> = await this.db.query(aql`
+    FOR o IN Organization
+        RETURN UNSET(o, ["_id", "_rev", "_key"])
+  `);
+  return await cursor.all();
+}
+
 export async function listOrganizations(this: LXCatDatabase) {
   const cursor: ArrayCursor<KeyedOrganization> = await this.db.query(aql`
     FOR o IN Organization

--- a/packages/database/src/cli/load-orgs.ts
+++ b/packages/database/src/cli/load-orgs.ts
@@ -3,10 +3,10 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import "./env.js";
-import { load_organizations_dir } from "../css/loaders.js";
+import { load_organizations_from_file } from "../css/loaders.js";
 import { db } from "../db.js";
 
 (async () => {
   const dir = process.argv[2];
-  await load_organizations_dir(db(), dir);
+  await load_organizations_from_file(db(), dir);
 })();

--- a/packages/database/src/css/loaders.ts
+++ b/packages/database/src/css/loaders.ts
@@ -31,6 +31,18 @@ const load_organization_from_file = async (db: LXCatDatabase, path: string) => {
   console.log(`Inserted organization ${org.name} with key ${orgId}.`);
 };
 
+export const load_organizations_from_file = async (
+  db: LXCatDatabase,
+  path: string,
+) => {
+  const content = await readFile(path, { encoding: "utf8" });
+  const orgs = Contributor.array().parse(JSON.parse(content));
+  for (const org of orgs) {
+    const orgId = await db.addOrganization(org);
+    console.log(`Inserted organization ${org.name} with key ${orgId}.`);
+  }
+};
+
 export const load_organizations_dir = async (
   db: LXCatDatabase,
   dir: string,

--- a/packages/database/src/lxcat-database.ts
+++ b/packages/database/src/lxcat-database.ts
@@ -19,6 +19,7 @@ import {
   getUserByEmail,
   getUserByKey,
   linkAccount,
+  listContributors,
   listOrganizations,
   listUsers,
   makeAdmin,
@@ -287,6 +288,8 @@ export class LXCatDatabase {
   public getSessionAndUser = getSessionAndUser;
   public updateSession = updateSession;
   public dropSession = dropSession;
+
+  public listContributors = listContributors;
 
   public listOrganizations = listOrganizations;
   public addOrganization = addOrganization;


### PR DESCRIPTION
Adds a table of data contributors to the homepage. This table lists the contributor name, contact information, the number of converted sets, a link to the LXCat 2 equivalent, and upon row expansion the description, and how to reference the database.

Resolves #1364 