### PR TITLE
Avoid calling protected endpoints on the inspect page when downloading data

### DIFF
--- a/app/src/app/api/scat-cs/inspect/legacy/route.ts
+++ b/app/src/app/api/scat-cs/inspect/legacy/route.ts
@@ -31,8 +31,7 @@ const router = RouteBuilder
     );
 
     const data: LTPMixtureWithReference = {
-      // FIXME: Return correct $schema url.
-      $schema: "",
+      $schema: `${process.env.NEXT_PUBLIC_URL}/scat-css/LTPMixture`,
       url: `${process.env.NEXT_PUBLIC_URL}/scat-cs/inspect?ids=${
         ctx.parsedParams.query.ids.join(",")
       }`,

--- a/app/src/app/api/scat-cs/inspect/route.ts
+++ b/app/src/app/api/scat-cs/inspect/route.ts
@@ -23,8 +23,7 @@ const router = RouteBuilder
   .get(async (_, ctx) => {
     const params = ctx.parsedParams;
     const data: LTPMixtureWithReference = {
-      // FIXME: Return correct $schema url.
-      $schema: "",
+      $schema: `${process.env.NEXT_PUBLIC_URL}/scat-css/LTPMixture`,
       url: `${process.env.NEXT_PUBLIC_URL}/scat-cs/inspect?ids=${
         params.query.ids.join(",")
       }`,

--- a/app/src/app/api/scat-css/LTPMixture/openapi.ts
+++ b/app/src/app/api/scat-css/LTPMixture/openapi.ts
@@ -1,0 +1,33 @@
+// SPDX-FileCopyrightText: LXCat team
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { registry } from "@/docs/openapi";
+import { extendZodWithOpenApi } from "@asteasolutions/zod-to-openapi";
+import { LTPDocumentJSONSchema } from "@lxcat/schema/json-schema";
+import { z } from "zod";
+
+export async function register() {
+  extendZodWithOpenApi(z);
+
+  registry().registerPath({
+    method: "get",
+    path: "/scat-css/LTPMixture",
+    tags: ["Schema"],
+    description:
+      "Get the JSON schema definition for a selection of low-temperature plasma data.",
+    responses: {
+      200: {
+        description:
+          "Returns the JSON schema definition of the LTPMixture type.",
+        content: {
+          "application/schema+json": {
+            schema: {
+              $ref: LTPDocumentJSONSchema.$schema?.replace(/^http:/, "https:"),
+            },
+          },
+        },
+      },
+    },
+  });
+}

--- a/app/src/app/api/scat-css/LTPMixture/route.ts
+++ b/app/src/app/api/scat-css/LTPMixture/route.ts
@@ -1,0 +1,19 @@
+// SPDX-FileCopyrightText: LXCat team
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { okJsonResponse } from "@/shared/api-responses";
+import { LTPMixtureJSONSchema } from "@lxcat/schema/json-schema";
+import { RouteBuilder } from "../../route-builder";
+
+// Route to host JSON schema of LTPMixture.
+const router = RouteBuilder
+  .init()
+  .get(async () => {
+    let res = okJsonResponse(LTPMixtureJSONSchema);
+    res.headers.append("Content-Type", "application/schema+json");
+    return res;
+  })
+  .compile();
+
+export { router as GET };

--- a/app/src/app/api/scat-css/[id]/legacy/route.ts
+++ b/app/src/app/api/scat-css/[id]/legacy/route.ts
@@ -49,7 +49,7 @@ const router = RouteBuilder
       );
 
       const dataWithRef: VersionedLTPDocumentWithReference = {
-        $schema: "",
+        $schema: `${process.env.NEXT_PUBLIC_URL}/scat-css/LTPMixture`,
         url:
           `${process.env.NEXT_PUBLIC_URL}/scat-css/${ctx.parsedParams.path.id}`,
         termsOfUse:

--- a/app/src/app/api/scat-css/[id]/route.ts
+++ b/app/src/app/api/scat-css/[id]/route.ts
@@ -34,9 +34,7 @@ const router = RouteBuilder
       }
 
       const dataWithRef: VersionedLTPDocumentWithReference = {
-        // TODO: Schema endpoint does not exist.
-        $schema:
-          `${process.env.NEXT_PUBLIC_URL}/api/scat-css/CrossSectionSetRaw.schema.json`,
+        $schema: `${process.env.NEXT_PUBLIC_URL}/api/scat-css/LTPDocument`,
         url: `${process.env.NEXT_PUBLIC_URL}/scat-css/${params.path.id}`,
         termsOfUse:
           `${process.env.NEXT_PUBLIC_URL}/scat-css/${params.path.id}#termsOfUse`,

--- a/app/src/app/scat-cs/inspect/button-multi-download.tsx
+++ b/app/src/app/scat-cs/inspect/button-multi-download.tsx
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
+import { MaybePromise } from "@/app/api/util";
 import { Button, Menu } from "@mantine/core";
 import { IconDownload } from "@tabler/icons-react";
 import { LinkToggle } from "./link-toggle";
@@ -12,7 +13,7 @@ export const ButtonMultiDownload = (
     entries: Array<
       {
         text: string;
-        link: string;
+        link: string | (() => MaybePromise<void>);
         icon?: React.ReactNode;
         disabled?: boolean;
         fileName?: string;
@@ -37,21 +38,34 @@ export const ButtonMultiDownload = (
       </Menu.Target>
       <Menu.Dropdown>
         {entries.map(({ text, link, icon, disabled, fileName }, index) => (
-          <LinkToggle
-            key={index}
-            style={{
-              textDecoration: "none",
-            }}
-            href={disabled ? "" : link}
-            target="_blank"
-            rel="noreferrer"
-            download={fileName ?? true}
-            disabled={disabled}
-          >
-            <Menu.Item leftSection={icon} disabled={disabled}>
-              {text}
-            </Menu.Item>
-          </LinkToggle>
+          typeof link === "string"
+            ? (
+              <LinkToggle
+                key={index}
+                style={{
+                  textDecoration: "none",
+                }}
+                href={disabled ? "" : link}
+                target="_blank"
+                rel="noreferrer"
+                download={fileName ?? true}
+                disabled={disabled}
+              >
+                <Menu.Item leftSection={icon} disabled={disabled}>
+                  {text}
+                </Menu.Item>
+              </LinkToggle>
+            )
+            : (
+              <Menu.Item
+                key={index}
+                onClick={async () => await link()}
+                leftSection={icon}
+                disabled={disabled}
+              >
+                {text}
+              </Menu.Item>
+            )
         ))}
       </Menu.Dropdown>
     </Menu>

--- a/app/src/app/scat-cs/inspect/legacy-action.ts
+++ b/app/src/app/scat-cs/inspect/legacy-action.ts
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: LXCat team
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+"use server";
+
+import { reference2bibliography } from "@/shared/cite";
+import { mapObject } from "@/shared/utils";
+import { convertMixture } from "@lxcat/converter";
+import { LTPMixture, LTPMixtureWithReference } from "@lxcat/schema";
+
+export const toLegacyAction = async (mixture: LTPMixture) => {
+  const references = mapObject(
+    mixture.references,
+    ([key, reference]) => [key, reference2bibliography(reference)],
+  );
+
+  const ids = mixture
+    .processes
+    .flatMap((process) => process.info)
+    .map((info) => info._key);
+
+  const data: LTPMixtureWithReference = {
+    $schema: `${process.env.NEXT_PUBLIC_URL}/scat-css/LTPMixture`,
+    url: `${process.env.NEXT_PUBLIC_URL}/scat-cs/inspect?ids=${ids.join(",")}`,
+    termsOfUse: `${process.env.NEXT_PUBLIC_URL}/scat-cs/inspect?ids=${
+      ids.join(",")
+    }#termsOfUse`,
+    ...mixture,
+    references,
+  };
+
+  return convertMixture(data);
+};

--- a/app/src/app/scat-cs/inspect/plot-page-client.tsx
+++ b/app/src/app/scat-cs/inspect/plot-page-client.tsx
@@ -4,6 +4,7 @@
 
 "use client";
 
+import { LTPMixture } from "@lxcat/schema";
 import {
   Alert,
   Button,
@@ -29,6 +30,7 @@ import { ButtonClipboard } from "./button-clipboard";
 import { ButtonMultiDownload } from "./button-multi-download";
 import { colorScheme } from "./colors";
 import classes from "./inspect.module.css";
+import { toLegacyAction } from "./legacy-action";
 import { ProcessTable } from "./process-table";
 import { Reference } from "./reference";
 import { TermsOfUseCheck } from "./terms-of-use-check";
@@ -46,13 +48,28 @@ const Chart = dynamic(
   },
 );
 
+const downloadFile = (
+  jsonString: string,
+  fileName: string,
+  type: string = "application/json",
+) => {
+  const file = new Blob([jsonString], { type });
+  const element = document.createElement("a");
+  element.href = URL.createObjectURL(file);
+  element.download = fileName;
+  document.body.appendChild(element);
+  element.click();
+  element.remove();
+};
+
 const NUM_LINES_INIT = 5;
 
 export const PlotPageClient = (
-  { processes, refs, setMismatch, permaLink, forceTermsOfUse }: {
+  { processes, refs, setMismatch, data, permaLink, forceTermsOfUse }: {
     processes: Array<DenormalizedProcess>;
     refs: Array<FormattedReference>;
     setMismatch: boolean;
+    data: LTPMixture;
     permaLink: string;
     forceTermsOfUse?: boolean;
   },
@@ -110,11 +127,16 @@ export const PlotPageClient = (
                 <ButtonMultiDownload
                   entries={[{
                     text: "JSON",
-                    link: `/api/scat-cs/inspect?ids=${idsString}`,
+                    link: async () =>
+                      downloadFile(JSON.stringify(data), "lxcat-data.json"),
                     icon: <IconCodeDots stroke={1.5} />,
                   }, {
                     text: "Plaintext",
-                    link: `/api/scat-cs/inspect/legacy?ids=${idsString}`,
+                    link: async () =>
+                      downloadFile(
+                        await toLegacyAction(data),
+                        "lxcat-data.txt",
+                      ),
                     icon: <IconFileText stroke={1.5} />,
                   }]}
                 >

--- a/app/src/app/scat-cs/inspect/plot-page.tsx
+++ b/app/src/app/scat-cs/inspect/plot-page.tsx
@@ -31,6 +31,7 @@ export const PlotPage = ({
       processes={processes}
       refs={formattedRefs}
       setMismatch={hasMixedCompleteSets}
+      data={bag}
       permaLink={permaLink}
       forceTermsOfUse={forceTermsOfUse}
     />


### PR DESCRIPTION
The `Download data -> JSON`, and `Download data -> Plaintext` buttons used to call protected endpoints (endpoints that require login). This is no longer the case, as data is now passed directly from the server to the client component. A server action is used to convert the data into legacy format.