### PR TITLE
Add a demo alert box to the top of every page

### DIFF
--- a/app/e2e/static.spec.ts
+++ b/app/e2e/static.spec.ts
@@ -6,11 +6,11 @@ import { expect, test } from "playwright-test-coverage";
 
 test("/", async ({ page }) => {
   await page.goto("/");
-  const h1 = page.locator("h1");
-  await expect(h1).toContainText("Welcome to LXCat");
+  const legend = page.locator("legend");
+  await expect(legend).toContainText("List of data contributors");
 });
 
-test("/docs/index", async ({ page }) => {
+test("/docs/0-index", async ({ page }) => {
   test.slow();
   await page.goto("/docs/0-index");
   const h1 = page.locator("h1");

--- a/app/src/app/api-doc/page-client.tsx
+++ b/app/src/app/api-doc/page-client.tsx
@@ -7,10 +7,9 @@
 import { RedocStandalone } from "redoc";
 
 export function DocsPageClient({ spec }: { spec: any }) {
-  const url = "/api/doc/";
   return (
-    <section className="container">
-      <RedocStandalone spec={spec} />
+    <section className="container" style={{ marginTop: 10 }}>
+      <RedocStandalone options={{ scrollYOffset: 30 }} spec={spec} />
     </section>
   );
 }

--- a/app/src/app/contributor-table.tsx
+++ b/app/src/app/contributor-table.tsx
@@ -22,7 +22,7 @@ export const ContributorTable = (
   return (
     <DataTable
       withTableBorder
-      height={600}
+      height={800}
       borderRadius="sm"
       highlightOnHover
       records={contributors}

--- a/app/src/app/layout.tsx
+++ b/app/src/app/layout.tsx
@@ -7,6 +7,7 @@ import "@mantine/code-highlight/styles.css";
 import "mantine-datatable/styles.css";
 import "@/styles/globals.css";
 
+import { DemoAlert } from "@/shared/demo-alert";
 import ErrorBoundary from "@/shared/error-boundary";
 import { NavBar } from "@/shared/header/nav-bar";
 import { ColorSchemeScript } from "@mantine/core";
@@ -26,6 +27,7 @@ const MyApp = ({ children }: RootLayoutProps) => {
         <Provider>
           <div style={{ boxSizing: "border-box" }}>
             <NavBar />
+            <DemoAlert />
             <ErrorBoundary>
               {children}
             </ErrorBoundary>

--- a/app/src/app/page.tsx
+++ b/app/src/app/page.tsx
@@ -36,17 +36,10 @@ const Home = async () => {
       <Script key="jsonld-logo" {...jsonLdScriptProps(jsonLDLogo)} />
       <Script key="jsonld-website" {...jsonLdScriptProps(jsonLDWebsite)} />
 
-      <Title order={1} style={{ margin: 10 }}>Welcome to LXCat!</Title>
-
-      <Text style={{ margin: 10 }}>
-        This is the next version of the LXCat web site and is under heavy
-        construction.
-      </Text>
-
-      <Fieldset>
-        <Title order={2} style={{ marginLeft: 10, marginBottom: 10 }}>
-          List of data contributors
-        </Title>
+      <Fieldset
+        legend=<Text fw={700}>List of data contributors</Text>
+        style={{ marginTop: 15, marginLeft: 10, marginRight: 10 }}
+      >
         <ContributorTable contributors={contributors} />
       </Fieldset>
     </>

--- a/app/src/shared/demo-alert.tsx
+++ b/app/src/shared/demo-alert.tsx
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: LXCat team
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import { Alert, Center } from "@mantine/core";
+import { IconInfoCircle } from "@tabler/icons-react";
+import Link from "next/link";
+
+export const DemoAlert = () => (
+  <Center>
+    <Alert
+      icon={<IconInfoCircle />}
+      title="Welcome to the demo deployment of LXCat 3!"
+      variant="filled"
+      color="red"
+      style={{ width: "90%", marginTop: 10 }}
+    >
+      This is the next version of the LXCat web site. The purpose of this demo
+      is to gather feedback on the interfaces, data format, and general
+      usability of the new website. Please communicate such feedback in the form
+      of issues on the{" "}
+      <Link href="https://github.com/LXCat-project/LXCat" target="_blank">
+        LXCat GitHub page
+      </Link>{" "}
+      or in the form of an e-mail to{" "}
+      <Link href="mailto:info@lxcat.net">info@lxcat.net</Link>.{" "}
+      <b>
+        Do not use data downloaded from this deployment in publications. Until
+        the platform is officially released, unique identifiers of datasets and
+        cross sections will be unstable.
+      </b>{" "}
+      For now, please obtain your cross section data from{" "}
+      <Link href={"https://www.lxcat.net"} target="_blank">
+        the LXCat 2 website.
+      </Link>
+    </Alert>
+  </Center>
+);

--- a/app/src/shared/layout.tsx
+++ b/app/src/shared/layout.tsx
@@ -5,6 +5,7 @@
 import Head from "next/head";
 import Link from "next/link";
 import { ReactNode } from "react";
+import { DemoAlert } from "./demo-alert";
 import { NavBar } from "./header/nav-bar";
 
 interface Props {
@@ -28,6 +29,7 @@ export const Layout = ({ children, title = "" }: Props) => {
         />
       </Head>
       <NavBar />
+      <DemoAlert />
       <main style={{ padding: 10 }}>{children}</main>
       <footer>
         <div style={{ padding: 10 }}>


### PR DESCRIPTION
This pull request includes several updates to the UI components and the introduction of a new `DemoAlert` component. This component is displayed at the top of every page, and alerts the user that they should not use data downloaded from the demo version in their publications. It also contains several links to LXCat 2, info@lxcat.net, and this git repository.

Resolves #1347 

### UI Enhancements:

* [`app/src/app/api-doc/page-client.tsx`](diffhunk://#diff-5698586d0a977572b74920e63d51b408a2b5fb1b954ce064f0f2c3fc454b3b04L10-R12): Updated the `DocsPageClient` component to include a margin at the top and added scroll offset options to the `RedocStandalone` component.
* [`app/src/app/contributor-table.tsx`](diffhunk://#diff-34475c58bc257fb0ee999bff5997a96916d953dfcfc3d00f6c9e7c7b4ab916a6L25-R25): Increased the height of the `ContributorTable` from 600 to 800 for better visibility.
* [`app/src/app/page.tsx`](diffhunk://#diff-16e554f695aa6d116c669a9adf50b812f8cb4204511ba31ab72ebd4ec3472dc0L39-R42): Refactored the `Home` component to improve the layout of the contributors list, using a `Fieldset` with a styled legend.

### Introduction of `DemoAlert` Component:

* [`app/src/shared/demo-alert.tsx`](diffhunk://#diff-ffb6f2eeb7f7a3d484459a5e96034d329cd14626641fba0bf110c91e69f68f49R1-R38): Added a new `DemoAlert` component to display a welcome message and important information about the demo deployment.
* [`app/src/app/layout.tsx`](diffhunk://#diff-5b67baf22505aea33188d52dc7a36f0a902ee6843be3281ed2da639b0d5701feR10): Included the `DemoAlert` component in the main layout to ensure it is displayed on all pages. [[1]](diffhunk://#diff-5b67baf22505aea33188d52dc7a36f0a902ee6843be3281ed2da639b0d5701feR10) [[2]](diffhunk://#diff-5b67baf22505aea33188d52dc7a36f0a902ee6843be3281ed2da639b0d5701feR30)
* [`app/src/shared/layout.tsx`](diffhunk://#diff-58c1d7fe8e1c3b49b5485c0e85465ee0b159fbec06fa984c1c3821e93d2b84b9R8): Added the `DemoAlert` component to the shared layout for consistent messaging across different sections of the application. [[1]](diffhunk://#diff-58c1d7fe8e1c3b49b5485c0e85465ee0b159fbec06fa984c1c3821e93d2b84b9R8) [[2]](diffhunk://#diff-58c1d7fe8e1c3b49b5485c0e85465ee0b159fbec06fa984c1c3821e93d2b84b9R32)