### PR TITLE
Split the LXCat and data references in the terms-of-use

### DIFF
--- a/app/src/app/scat-cs/inspect/how-to-cite.tsx
+++ b/app/src/app/scat-cs/inspect/how-to-cite.tsx
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
 import { Reference } from "@lxcat/schema";
+import { Stack, Text } from "@mantine/core";
 import { ReferenceList } from "./reference-list";
 import { FormattedReference } from "./types";
 
@@ -309,11 +310,17 @@ export const HowToCite = (
   { references }: { references: Array<FormattedReference> },
 ) => {
   return (
-    <div>
-      <h2>How to reference data</h2>
-      <ReferenceList
-        references={[...references, ...FORMATTED_LXCAT_REFERENCES]}
-      />
-    </div>
+    <Stack>
+      <div>
+        <Text fw={700} size="lg" mb="xs">How to reference LXCat</Text>
+        <ReferenceList references={FORMATTED_LXCAT_REFERENCES} />
+      </div>
+      <div>
+        <Text fw={700} size="lg" mb="xs">
+          How to reference the selected data
+        </Text>
+        <ReferenceList references={references} />
+      </div>
+    </Stack>
   );
 };

--- a/app/src/app/scat-css/[id]/page.tsx
+++ b/app/src/app/scat-css/[id]/page.tsx
@@ -19,9 +19,17 @@ interface BagProps {
 
 interface URLParams {
   params?: Promise<{ id: string }>;
+  searchParams?: Promise<{ termsOfUse?: string }>;
 }
 
-const ScatteringCrossSectionSelectionPage = async ({ params }: URLParams) => {
+const SearchParams = z.object({
+  termsOfUse: z.string().optional(),
+});
+
+const ScatteringCrossSectionSelectionPage = async (
+  { params, searchParams }: URLParams,
+) => {
+  const { termsOfUse } = SearchParams.parse(await searchParams);
   return (
     <>
       <Script
@@ -29,8 +37,12 @@ const ScatteringCrossSectionSelectionPage = async ({ params }: URLParams) => {
         src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg.js"
       />
       {params
-        // FIXME: Use a specialized component to render a single set.
-        ? <PlotPage {...(await fetchProps((await params).id))} />
+        ? (
+          <PlotPage
+            {...(await fetchProps((await params).id))}
+            forceTermsOfUse={termsOfUse ? true : false}
+          />
+        )
         : <></>}
     </>
   );


### PR DESCRIPTION
Also allows for forcing the terms-of-use to pop-up in the scat-css inspect page by passing e.g. `?termsOfUse="true"`.

Resolves #54 