### PR TITLE
Remove unavailable sets from the selection

### DIFF
--- a/app/src/shared/swr-reaction-picker.tsx
+++ b/app/src/shared/swr-reaction-picker.tsx
@@ -240,7 +240,11 @@ export const SWRReactionPicker = ({
           selection: new Set(selection.set),
           unfolded: unfoldedOrgs,
           onSetChecked(setId, checked) {
-            const newSelectedCSSets = new Set(selection.set);
+            const newSelectedCSSets = new Set(
+              selection.set.filter((set) =>
+                Object.values(csSets).some((summ) => set in summ.sets)
+              ),
+            );
 
             checked
               ? newSelectedCSSets.add(setId)
@@ -249,7 +253,11 @@ export const SWRReactionPicker = ({
             onCSSetsChange(newSelectedCSSets);
           },
           onOrganizationChecked(id, checked) {
-            const newSelectedCSSets = new Set(selection.set);
+            const newSelectedCSSets = new Set(
+              selection.set.filter((set) =>
+                Object.values(csSets).some((summ) => set in summ.sets)
+              ),
+            );
 
             Object.keys(csSets[id].sets).forEach((setId) => {
               checked


### PR DESCRIPTION
This fixes the client-side exception in the reaction template picker.

Resolves #1405