### PR TITLE
Return serialized species descriptions on all endpoints

### DIFF
--- a/app/src/app/api/scat-css/[id]/legacy/route.ts
+++ b/app/src/app/api/scat-css/[id]/legacy/route.ts
@@ -38,15 +38,6 @@ const router = RouteBuilder
         data.references,
         ([key, reference]) => [key, reference2bibliography(reference)],
       );
-      const states = mapObject(
-        data.states,
-        (
-          [key, state],
-        ) => [key, {
-          detailed: state,
-          serialized: AnySpeciesSerializable.parse(state).serialize(),
-        }],
-      );
 
       const dataWithRef: VersionedLTPDocumentWithReference = {
         $schema: `${process.env.NEXT_PUBLIC_URL}/scat-css/LTPMixture`,
@@ -55,12 +46,11 @@ const router = RouteBuilder
         termsOfUse:
           `${process.env.NEXT_PUBLIC_URL}/scat-css/${ctx.parsedParams.path.id}#termsOfUse`,
         ...data,
+        references,
       };
 
       const { convertDocument } = await import("@lxcat/converter");
-      let res = okResponse(
-        convertDocument({ ...dataWithRef, states, references }),
-      );
+      let res = okResponse(convertDocument(dataWithRef));
       res.headers.append("Content-Type", "text/plain");
       res.headers.append(
         "Content-Disposition",

--- a/packages/database/src/css/queries/author-read.ts
+++ b/packages/database/src/css/queries/author-read.ts
@@ -73,7 +73,10 @@ export async function byOwnerAndId(
                             FILTER state.detailed.composition == co._id
                             return co.definition
                         )
-                        RETURN {[state._key]: MERGE_RECURSIVE(state.detailed, {composition})}
+                        RETURN {[state._key]: {
+                          detailed: MERGE_RECURSIVE(state.detailed, {composition}), 
+                          serialized: state.serialized
+                        }}
                     )
                     LET produces = (
                       FOR state IN OUTBOUND r Produces
@@ -82,7 +85,10 @@ export async function byOwnerAndId(
                             FILTER state.detailed.composition == co._id
                             return co.definition
                         )
-                        RETURN {[state._key]: MERGE_RECURSIVE(state.detailed, {composition})}
+                        RETURN {[state._key]: {
+                          detailed: MERGE_RECURSIVE(state.detailed, {composition}), 
+                          serialized: state.serialized
+                        }}
                     )
                     RETURN MERGE(UNION(produces, consumes))
               )

--- a/packages/database/src/css/queries/author-write.spec.ts
+++ b/packages/database/src/css/queries/author-write.spec.ts
@@ -4,7 +4,8 @@
 
 import { beforeAll, describe, expect, it } from "vitest";
 
-import { EditedLTPDocument, VersionedLTPDocument } from "@lxcat/schema";
+import { VersionedLTPDocument } from "@lxcat/schema";
+import { intoEditable } from "@lxcat/schema/process";
 import { systemDb } from "../../system-db.js";
 import { testSpecies } from "../../test/species.js";
 import { LXCatTestDatabase } from "../../testutils.js";
@@ -109,10 +110,7 @@ describe("given filled ArangoDB container", () => {
             css2.description = "Some description 1st edit";
             keycss2 = await db.updateSet(
               keycss1,
-              EditedLTPDocument.parse({
-                ...css2,
-                contributor: css2.contributor.name,
-              }),
+              intoEditable(css2),
               "First edit",
             );
           }
@@ -319,10 +317,7 @@ describe("given filled ArangoDB container", () => {
       let css2: VersionedLTPDocument;
 
       beforeAll(async () => {
-        const cssdraft = EditedLTPDocument.parse({
-          ...css1,
-          contributor: css1.contributor.name,
-        });
+        const cssdraft = intoEditable(deepClone(css1));
         const ion = Object.values(cssdraft.states).find(
           (species) => species.charge === 1,
         );
@@ -348,10 +343,10 @@ describe("given filled ArangoDB container", () => {
 
       it("draft set should have new id for state with particle A", () => {
         const oldStateEntry = Object.entries(css1.states).find(
-          ([, species]) => species.charge === 1,
+          ([, species]) => species.detailed.charge === 1,
         );
         const newStateEntry = Object.entries(css2.states).find(
-          ([, species]) => species.charge === 99,
+          ([, species]) => species.detailed.charge === 99,
         );
 
         expect(oldStateEntry![0]).not.toEqual(newStateEntry![0]);
@@ -374,7 +369,7 @@ describe("given filled ArangoDB container", () => {
             expect(info).toEqual(otherInfo);
           } else {
             const other = css2.processes.find(({ reaction }) =>
-              css2.states[reaction.rhs[0].state].charge === 99
+              css2.states[reaction.rhs[0].state].detailed.charge === 99
             )!;
 
             expect(process.info[0]._key).not.toEqual(other.info[0]._key);

--- a/packages/database/src/css/queries/delete-set.spec.ts
+++ b/packages/database/src/css/queries/delete-set.spec.ts
@@ -4,12 +4,8 @@
 
 import { beforeAll, describe, expect, it } from "vitest";
 
-import {
-  EditedLTPDocument,
-  Status,
-  VersionedLTPDocument,
-  VersionInfo,
-} from "@lxcat/schema";
+import { Status, VersionedLTPDocument, VersionInfo } from "@lxcat/schema";
+import { intoEditable } from "@lxcat/schema/process";
 import { systemDb } from "../../system-db.js";
 import { LXCatTestDatabase } from "../../testutils.js";
 import { KeyedSet } from "../public.js";
@@ -209,13 +205,11 @@ describe("deleting a published cross section with one shared cross section", () 
       expect.fail("Should have created first set");
     }
 
-    const editedSet = EditedLTPDocument.parse({
-      ...css2,
-      name: "Some other name",
-      contributor: css2.contributor.name,
-    });
+    const editedSet = intoEditable(css2);
 
+    editedSet.name = "Some other name";
     editedSet.processes.pop(); // delete second cross section in second set
+
     keycss2 = await db.createSet(editedSet, "published");
 
     await db.deleteSet(keycss1, "My retract message");
@@ -380,11 +374,8 @@ describe("deleting a draft cross section set with one shared cross section", () 
       expect.fail("Should have created first set");
     }
 
-    const editedSet: EditedLTPDocument = {
-      ...css2,
-      name: "Some other name",
-      contributor: css2.contributor.name,
-    };
+    const editedSet = intoEditable(css2);
+    editedSet.name = "Some other name";
 
     editedSet.processes.pop(); // delete second section in second set
 

--- a/packages/database/src/css/queries/public.ts
+++ b/packages/database/src/css/queries/public.ts
@@ -68,7 +68,10 @@ export async function byId(
                     FILTER c.detailed.composition == co._id
                     return co.definition
                 )
-                RETURN {[c._key]: MERGE_RECURSIVE(c.detailed, {composition})}
+                RETURN {[c._key]: {
+                  detailed: MERGE_RECURSIVE(c.detailed, {composition}), 
+                  serialized: c.serialized
+                }}
             )
             LET produces = (
               FOR p IN OUTBOUND r Produces
@@ -77,7 +80,10 @@ export async function byId(
                     FILTER p.detailed.composition == co._id
                     return co.definition
                 )
-                RETURN {[p._key]: MERGE_RECURSIVE(p.detailed, {composition})}
+                RETURN {[p._key]: {
+                  detailed: MERGE_RECURSIVE(p.detailed, {composition}), 
+                  serialized: p.serialized
+                }}
             )
             RETURN MERGE(UNION(consumes, produces))
       )

--- a/packages/database/src/css/queries/publish.spec.ts
+++ b/packages/database/src/css/queries/publish.spec.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-import { EditedLTPDocument } from "@lxcat/schema";
+import { intoEditable } from "@lxcat/schema/process";
 import { aql } from "arangojs";
 import { beforeAll, describe, expect, it } from "vitest";
 import { systemDb } from "../../system-db.js";
@@ -36,10 +36,7 @@ describe("given 2 draft cross section sets which shares a draft cross section", 
     if (css1 === null) {
       expect.fail("Should have created first set");
     }
-    const draft = EditedLTPDocument.parse({
-      ...css1,
-      contributor: css1.contributor.name,
-    });
+    const draft = intoEditable(css1);
     draft.name = "Some other name";
     keycss2 = await db.createSet(draft, "draft");
     return async () => truncateCrossSectionSetCollections(db.getDB());
@@ -158,10 +155,7 @@ describe("given a published cross section set and a draft cross section with a d
     if (css1 === null) {
       expect.fail("Should have created first set");
     }
-    const draft = EditedLTPDocument.parse({
-      ...css1,
-      contributor: css1.contributor.name,
-    });
+    const draft = intoEditable(css1);
     draft.name = "Some other name";
     draft.processes[0].info[0].threshold = 888;
     draft.processes.pop();

--- a/packages/database/src/css/queries/update-set.spec.ts
+++ b/packages/database/src/css/queries/update-set.spec.ts
@@ -6,13 +6,8 @@ import { beforeAll, describe, expect, it } from "vitest";
 
 import { aql } from "arangojs";
 
-import {
-  EditedLTPDocument,
-  Reference,
-  Status,
-  VersionedLTPDocument,
-} from "@lxcat/schema";
-import { ReactionEntry } from "@lxcat/schema/process";
+import { Reference, Status, VersionedLTPDocument } from "@lxcat/schema";
+import { intoEditable, ReactionEntry } from "@lxcat/schema/process";
 import { SerializedSpecies } from "@lxcat/schema/species";
 import { ArangojsError } from "arangojs/lib/request.node.js";
 import {
@@ -118,10 +113,7 @@ describe("given published cross section set where data of 1 published cross sect
     if (css1 === null) {
       throw Error(`Failed to find ${keycss1}`);
     }
-    const draft = EditedLTPDocument.parse({
-      ...css1,
-      contributor: css1.contributor.name,
-    });
+    const draft = intoEditable(css1);
     draft.processes[1].info[0].data.values = [
       [1, 3.14e-20],
       [2, 3.15e-20],
@@ -473,10 +465,7 @@ describe("given draft cross section set where its cross section data is altered"
     if (css1 === null) {
       throw Error(`Failed to find ${keycss1}`);
     }
-    const draft = EditedLTPDocument.parse({
-      ...css1,
-      contributor: css1.contributor.name,
-    });
+    const draft = intoEditable(css1);
     draft.processes[0].info[0].data.values = [
       [1, 3.14e-20],
       [2, 3.15e-20],
@@ -591,10 +580,7 @@ describe("given draft cross section set where its cross section data is added la
     if (css1 === null) {
       throw Error(`Failed to find ${keycss1}`);
     }
-    const draft = EditedLTPDocument.parse({
-      ...css1,
-      contributor: css1.contributor.name,
-    });
+    const draft = intoEditable(css1);
     draft.states = {
       electron: testSpecies.electron.detailed,
       argon: testSpecies.argon.detailed,
@@ -758,10 +744,7 @@ describe("given draft cross section set where its non cross section data is alte
     if (css1 === null) {
       throw Error(`Failed to find ${keycss1}`);
     }
-    const draft = EditedLTPDocument.parse({
-      ...css1,
-      contributor: css1.contributor.name,
-    });
+    const draft = intoEditable(css1);
     draft.description = "Some altered description";
     keycss2 = await db.updateSet(
       keycss1,
@@ -905,10 +888,7 @@ describe("given draft cross section set where its cross section state is altered
     if (css1 === null) {
       throw Error(`Failed to find ${keycss1}`);
     }
-    const draft = EditedLTPDocument.parse({
-      ...css1,
-      contributor: css1.contributor.name,
-    });
+    const draft = intoEditable(css1);
     draft.states.ion = testSpecies.ion.detailed;
     draft.processes[0].reaction.rhs[1].state = "ion";
     try {
@@ -1026,10 +1006,7 @@ describe("given draft cross section set where a reference is added to a cross se
     if (css1 === null) {
       throw Error(`Failed to find ${keycss1}`);
     }
-    const draft = EditedLTPDocument.parse({
-      ...css1,
-      contributor: css1.contributor.name,
-    });
+    const draft = intoEditable(css1);
 
     const r1: Reference = {
       type: "article",
@@ -1161,10 +1138,7 @@ describe("given draft cross section set where a reference is replaced in a cross
     if (css1 === null) {
       throw Error(`Failed to find ${keycss1}`);
     }
-    const draft = EditedLTPDocument.parse({
-      ...css1,
-      contributor: css1.contributor.name,
-    });
+    const draft = intoEditable(css1);
     const r2: Reference = {
       type: "article",
       id: "refid2",
@@ -1353,10 +1327,7 @@ describe("given draft cross section set where a reference is extended in a cross
     if (css1 === null) {
       throw Error(`Failed to find ${keycss1}`);
     }
-    const draft = EditedLTPDocument.parse({
-      ...css1,
-      contributor: css1.contributor.name,
-    });
+    const draft = intoEditable(css1);
     if (draft.processes[0].info[0]) {
       const refid = draft.processes[0].info[0].references[0];
       const ref =
@@ -1508,11 +1479,8 @@ describe("given updating published cross section set which already has draft", (
     if (css1 === null) {
       throw Error(`Failed to find ${keycss1}`);
     }
-    const draft = EditedLTPDocument.parse({
-      ...css1,
-      contributor: css1.contributor.name,
-      description: "Some new description",
-    });
+    const draft = intoEditable(css1);
+    draft.description = "Some new description";
     keycss2 = await db.updateSet(keycss1, draft, "Altered description");
     return async () => truncateCrossSectionSetCollections(db.getDB());
   });
@@ -1524,10 +1492,7 @@ describe("given updating published cross section set which already has draft", (
       if (css1 === null) {
         throw Error(`Failed to find ${keycss1}`);
       }
-      const secondDraft = EditedLTPDocument.parse({
-        ...css1,
-        contributor: css1.contributor.name,
-      });
+      const secondDraft = intoEditable(css1);
       await db.updateSet(keycss1, secondDraft, "another draft please");
     } catch (error) {
       expect(`${error}`).toMatch(
@@ -1607,10 +1572,7 @@ describe("given draft cross section set where a cross section is added from anot
     if (css1versioned === null) {
       expect.fail(`Failed to find draft with key ${keycss1}`);
     }
-    const draft2 = EditedLTPDocument.parse({
-      ...css1versioned,
-      contributor: css1versioned.contributor.name,
-    });
+    const draft2 = intoEditable(css1versioned);
     draft2.processes.push({
       reaction: cs1.reaction,
       info: [{ ...cs1.info[0], _key: keycs1 }],
@@ -1760,10 +1722,7 @@ describe("given draft cross section set where its charge in cross section is alt
     if (css1 === null) {
       throw Error(`Failed to find ${keycss1}`);
     }
-    const draft = EditedLTPDocument.parse({
-      ...css1,
-      contributor: css1.contributor.name,
-    });
+    const draft = intoEditable(css1);
     const stateA = Object.values(draft.states).find((s) => s.type === "Atom");
     if (stateA === undefined) {
       throw Error(`Failed to find state with composition=A in ${keycss1}`);
@@ -1955,10 +1914,7 @@ describe("given draft cross section set where its charge in cross section is alt
     if (css1 === null) {
       throw Error(`Failed to find ${keycss1}`);
     }
-    const draft = EditedLTPDocument.parse({
-      ...css1,
-      contributor: css1.contributor.name,
-    });
+    const draft = intoEditable(css1);
     const stateA = Object.values(draft.states).find((s) => s.type === "Atom");
     if (stateA === undefined) {
       throw Error(`Failed to find state with composition=A in ${keycss1}`);

--- a/packages/schema/src/process/into-editable.ts
+++ b/packages/schema/src/process/into-editable.ts
@@ -10,5 +10,9 @@ export const intoEditable = (doc: VersionedLTPDocument): EditedLTPDocument => {
 
   editable.contributor = doc.contributor.name;
 
-  return editable as EditedLTPDocument;
+  editable.states = Object.fromEntries(
+    Object.entries(doc.states).map(([key, value]) => [key, value.detailed]),
+  );
+
+  return EditedLTPDocument.parse(editable);
 };

--- a/packages/schema/src/versioned-document.ts
+++ b/packages/schema/src/versioned-document.ts
@@ -17,7 +17,7 @@ import { Contributor } from "./contributor.js";
 import { VersionedProcess } from "./process/versioned-process.js";
 import { SelfReference } from "./self-reference.js";
 import { SetHeader } from "./set-header.js";
-import { AnySpecies } from "./species/any-species.js";
+import { SerializedSpecies } from "./species/serialized.js";
 import { versioned } from "./versioned.js";
 
 const VersionedDocumentBody = <ReferenceType extends ZodTypeAny>(
@@ -27,7 +27,7 @@ const VersionedDocumentBody = <ReferenceType extends ZodTypeAny>(
     SetHeader(Contributor).merge(
       object({
         references: record(Reference),
-        states: record(AnySpecies),
+        states: record(SerializedSpecies),
         processes: array(
           VersionedProcess(string(), ReferenceRef(string().min(1))),
         ),


### PR DESCRIPTION
Previously only some endpoints provided serialized species information. This PR ensures all (relevant) endpoints return serialized species information. 