### PR TITLE
Add the `AtomLSUncoupled`, `AtomLSTwoTerm`, and `AtomLSJTwoTerm` atomic types

### DIFF
--- a/packages/schema/src/species/atoms/any-atom.ts
+++ b/packages/schema/src/species/atoms/any-atom.ts
@@ -7,12 +7,14 @@ import { Atom } from "./atom.js";
 import { AtomJ1L2 } from "./j1l2.js";
 import { AtomLS } from "./ls.js";
 import { AtomLS1 } from "./ls1.js";
+import { AtomLSJ } from "./lsj.js";
 import { AtomUnspecified } from "./unspecified.js";
 
 export const AnyAtom = discriminatedUnion("type", [
   Atom,
   AtomUnspecified.plain,
   AtomLS.plain,
+  AtomLSJ.plain,
   AtomLS1.plain,
   AtomJ1L2.plain,
 ]);
@@ -22,6 +24,7 @@ export const AnyAtomSerializable = discriminatedUnion("type", [
   Atom,
   AtomUnspecified.serializable,
   AtomLS.serializable,
+  AtomLSJ.serializable,
   AtomLS1.serializable,
   AtomJ1L2.serializable,
 ]);

--- a/packages/schema/src/species/atoms/any-atom.ts
+++ b/packages/schema/src/species/atoms/any-atom.ts
@@ -8,6 +8,8 @@ import { AtomJ1L2 } from "./j1l2.js";
 import { AtomLS } from "./ls.js";
 import { AtomLS1 } from "./ls1.js";
 import { AtomLSJ } from "./lsj.js";
+import { AtomLSTwoTerm } from "./two-term-ls.js";
+import { AtomLSJTwoTerm } from "./two-term-lsj.js";
 import { AtomUnspecified } from "./unspecified.js";
 
 export const AnyAtom = discriminatedUnion("type", [
@@ -15,6 +17,8 @@ export const AnyAtom = discriminatedUnion("type", [
   AtomUnspecified.plain,
   AtomLS.plain,
   AtomLSJ.plain,
+  AtomLSTwoTerm.plain,
+  AtomLSJTwoTerm.plain,
   AtomLS1.plain,
   AtomJ1L2.plain,
 ]);
@@ -25,6 +29,8 @@ export const AnyAtomSerializable = discriminatedUnion("type", [
   AtomUnspecified.serializable,
   AtomLS.serializable,
   AtomLSJ.serializable,
+  AtomLSTwoTerm.serializable,
+  AtomLSJTwoTerm.serializable,
   AtomLS1.serializable,
   AtomJ1L2.serializable,
 ]);

--- a/packages/schema/src/species/atoms/index.ts
+++ b/packages/schema/src/species/atoms/index.ts
@@ -8,3 +8,4 @@ export * from "./type-guard.js";
 export { AtomJ1L2 } from "./j1l2.js";
 export { AtomLS } from "./ls.js";
 export { AtomLS1 } from "./ls1.js";
+export { AtomLSJ } from "./lsj.js";

--- a/packages/schema/src/species/atoms/index.ts
+++ b/packages/schema/src/species/atoms/index.ts
@@ -9,3 +9,5 @@ export { AtomJ1L2 } from "./j1l2.js";
 export { AtomLS } from "./ls.js";
 export { AtomLS1 } from "./ls1.js";
 export { AtomLSJ } from "./lsj.js";
+export { AtomLSTwoTerm } from "./two-term-ls.js";
+export { AtomLSJTwoTerm } from "./two-term-lsj.js";

--- a/packages/schema/src/species/atoms/j1l2.ts
+++ b/packages/schema/src/species/atoms/j1l2.ts
@@ -15,14 +15,12 @@ import {
   ShellEntry,
   TotalAngularSpecifier,
 } from "./common.js";
+import { LSTerm, serializeLatexLSTerm, serializeLSTerm } from "./ls.js";
 import {
-  LSDescriptor,
-  LSTermUncoupled,
-  serializeLatexLSTerm,
-  serializeLatexLSTermImpl,
-  serializeLSTerm,
-  serializeLSTermImpl,
-} from "./ls.js";
+  LSJDescriptor,
+  serializeLatexLSJTerm,
+  serializeLSJTerm,
+} from "./lsj.js";
 
 export const J1L2Term = object({
   K: number().multipleOf(0.5).nonnegative(),
@@ -32,7 +30,7 @@ export const J1L2Term = object({
 export type J1L2Term = TypeOf<typeof J1L2Term>;
 
 const J1L2Descriptor = buildTerm(
-  buildTwoTerm(LSDescriptor, buildTerm(array(ShellEntry), LSTermUncoupled)),
+  buildTwoTerm(LSJDescriptor, buildTerm(array(ShellEntry), LSTerm)),
   J1L2Term,
 );
 type J1L2Descriptor = TypeOf<typeof J1L2Descriptor>;
@@ -48,11 +46,11 @@ const serializeJ1L2 = (e: J1L2Descriptor): string => {
   return (
     serializeShellConfig(e.config.core.config)
     + "{"
-    + serializeLSTerm(e.config.core.term)
+    + serializeLSJTerm(e.config.core.term)
     + "}"
     + serializeShellConfig(e.config.excited.config)
     + "{"
-    + serializeLSTermImpl(e.config.excited.term)
+    + serializeLSTerm(e.config.excited.term)
     + "}"
     + serializeJ1L2Term(e.term)
   );
@@ -69,11 +67,11 @@ const serializeLatexJ1L2 = (e: J1L2Descriptor): string => {
   return (
     serializeShellConfig(e.config.core.config)
     + "("
-    + serializeLatexLSTerm(e.config.core.term)
+    + serializeLatexLSJTerm(e.config.core.term)
     + ")"
     + serializeShellConfig(e.config.excited.config)
     + "("
-    + serializeLatexLSTermImpl(e.config.excited.term)
+    + serializeLatexLSTerm(e.config.excited.term)
     + ")"
     + serializeLatexJ1L2Term(e.term)
   );

--- a/packages/schema/src/species/atoms/ls.ts
+++ b/packages/schema/src/species/atoms/ls.ts
@@ -55,6 +55,7 @@ export const LSComponent = makeComponent(
 );
 export type LSComponent = TypeOf<typeof LSComponent>;
 
+// TODO: After migration, this type should be renamed to `AtomLS`.
 export const AtomLS = makeAtom(
   "AtomLSUncoupled",
   SpeciesBase(AtomComposition),

--- a/packages/schema/src/species/atoms/ls.ts
+++ b/packages/schema/src/species/atoms/ls.ts
@@ -10,20 +10,15 @@ import { makeAtom } from "../generators.js";
 import {
   atomicOrbital,
   buildTerm,
-  serializeHalfInteger,
   serializeShellConfig,
   ShellEntry,
-  TotalAngularSpecifier,
 } from "./common.js";
 
-export const LSTermUncoupled = object({
+export const LSTerm = object({
   L: number().int().nonnegative(),
   S: number().multipleOf(0.5).nonnegative(),
   P: union([literal(-1), literal(1)]),
 });
-export type LSTermUncoupled = TypeOf<typeof LSTermUncoupled>;
-
-export const LSTerm = LSTermUncoupled.merge(TotalAngularSpecifier);
 export type LSTerm = TypeOf<typeof LSTerm>;
 
 export const LSDescriptor = buildTerm(array(ShellEntry), LSTerm);
@@ -31,14 +26,10 @@ type LSDescriptor = TypeOf<typeof LSDescriptor>;
 
 /// Serializer functions
 
-export const serializeLSTermImpl = (term: LSTermUncoupled): string => {
+export const serializeLSTerm = (term: LSTerm): string => {
   return `^${2 * term.S + 1}${atomicOrbital[term.L]}${
     term.P == -1 ? "^o" : ""
   }`;
-};
-
-export const serializeLSTerm = (term: LSTerm): string => {
-  return `${serializeLSTermImpl(term)}_${serializeHalfInteger(term.J)}`;
 };
 
 export const serializeLS = (e: LSDescriptor): string => {
@@ -46,14 +37,10 @@ export const serializeLS = (e: LSDescriptor): string => {
   return `${config}${config !== "" ? ":" : ""}${serializeLSTerm(e.term)}`;
 };
 
-export const serializeLatexLSTermImpl = (term: LSTermUncoupled): string => {
+export const serializeLatexLSTerm = (term: LSTerm): string => {
   return `{}^{${2 * term.S + 1}}\\mathrm{${atomicOrbital[term.L]}}${
     term.P == -1 ? "^o" : ""
   }`;
-};
-
-export const serializeLatexLSTerm = (term: LSTerm): string => {
-  return `${serializeLatexLSTermImpl(term)}_{${serializeHalfInteger(term.J)}}`;
 };
 
 export const serializeLatexLS = (e: LSDescriptor): string => {
@@ -69,7 +56,7 @@ export const LSComponent = makeComponent(
 export type LSComponent = TypeOf<typeof LSComponent>;
 
 export const AtomLS = makeAtom(
-  "AtomLS",
+  "AtomLSUncoupled",
   SpeciesBase(AtomComposition),
   LSComponent,
 );

--- a/packages/schema/src/species/atoms/ls1.ts
+++ b/packages/schema/src/species/atoms/ls1.ts
@@ -16,11 +16,7 @@ import {
   ShellEntry,
   TotalAngularSpecifier,
 } from "./common.js";
-import {
-  LSTermUncoupled,
-  serializeLatexLSTermImpl,
-  serializeLSTermImpl,
-} from "./ls.js";
+import { LSTerm, serializeLatexLSTerm, serializeLSTerm } from "./ls.js";
 
 export const LS1Term = object({
   L: number().int().nonnegative(),
@@ -32,8 +28,8 @@ export type LS1Term = TypeOf<typeof LS1Term>;
 
 export const LS1Descriptor = buildTerm(
   buildTwoTerm(
-    buildTerm(array(ShellEntry), LSTermUncoupled),
-    buildTerm(array(ShellEntry), LSTermUncoupled),
+    buildTerm(array(ShellEntry), LSTerm),
+    buildTerm(array(ShellEntry), LSTerm),
   ),
   LS1Term,
 );
@@ -53,11 +49,11 @@ export function serializeLS1(e: LS1Descriptor): string {
   return (
     serializeShellConfig(e.config.core.config)
     + "{"
-    + serializeLSTermImpl(e.config.core.term)
+    + serializeLSTerm(e.config.core.term)
     + "}"
     + serializeShellConfig(e.config.excited.config)
     + "{"
-    + serializeLSTermImpl(e.config.excited.term)
+    + serializeLSTerm(e.config.excited.term)
     + "}"
     + serializeLS1Term(e.term)
   );
@@ -73,11 +69,11 @@ export function serializeLatexLS1(e: LS1Descriptor): string {
   return (
     serializeShellConfig(e.config.core.config)
     + "("
-    + serializeLatexLSTermImpl(e.config.core.term)
+    + serializeLatexLSTerm(e.config.core.term)
     + ")"
     + serializeShellConfig(e.config.excited.config)
     + "("
-    + serializeLatexLSTermImpl(e.config.excited.term)
+    + serializeLatexLSTerm(e.config.excited.term)
     + ")"
     + serializeLatexLS1Term(e.term)
   );

--- a/packages/schema/src/species/atoms/lsj.ts
+++ b/packages/schema/src/species/atoms/lsj.ts
@@ -50,6 +50,7 @@ export const LSJComponent = makeComponent(
 );
 export type LSJComponent = TypeOf<typeof LSJComponent>;
 
+// TODO: After migration this type should be renamed to `AtomLSJ`.
 export const AtomLSJ = makeAtom(
   "AtomLS",
   SpeciesBase(AtomComposition),

--- a/packages/schema/src/species/atoms/lsj.ts
+++ b/packages/schema/src/species/atoms/lsj.ts
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: LXCat team
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { array, object, TypeOf } from "zod";
+import { makeComponent } from "../component.js";
+import { AtomComposition } from "../composition/atom.js";
+import { SpeciesBase } from "../composition/species-base.js";
+import { makeAtom } from "../generators.js";
+import {
+  buildTerm,
+  serializeHalfInteger,
+  serializeShellConfig,
+  ShellEntry,
+  TotalAngularSpecifier,
+} from "./common.js";
+import { LSTerm, serializeLatexLSTerm, serializeLSTerm } from "./ls.js";
+
+export const LSJTerm = object({
+  ...LSTerm.shape,
+  ...TotalAngularSpecifier.shape,
+});
+export type LSJTerm = TypeOf<typeof LSJTerm>;
+
+export const LSJDescriptor = buildTerm(array(ShellEntry), LSJTerm);
+type LSJDescriptor = TypeOf<typeof LSJDescriptor>;
+
+export const serializeLSJTerm = (term: LSJTerm): string => {
+  return `${serializeLSTerm(term)}_${serializeHalfInteger(term.J)}`;
+};
+
+export const serializeLSJ = (e: LSJDescriptor): string => {
+  const config = serializeShellConfig(e.config);
+  return `${config}${config !== "" ? ":" : ""}${serializeLSJTerm(e.term)}`;
+};
+
+export const serializeLatexLSJTerm = (term: LSJTerm): string => {
+  return `${serializeLatexLSTerm(term)}_{${serializeHalfInteger(term.J)}}`;
+};
+
+export const serializeLatexLSJ = (e: LSJDescriptor): string => {
+  const config = serializeShellConfig(e.config);
+  return `${config}${config != "" ? ":" : ""}${serializeLatexLSJTerm(e.term)}`;
+};
+
+export const LSJComponent = makeComponent(
+  LSJDescriptor,
+  serializeLSJ,
+  serializeLatexLSJ,
+);
+export type LSJComponent = TypeOf<typeof LSJComponent>;
+
+export const AtomLSJ = makeAtom(
+  "AtomLS",
+  SpeciesBase(AtomComposition),
+  LSJComponent,
+);

--- a/packages/schema/src/species/atoms/two-term-ls.ts
+++ b/packages/schema/src/species/atoms/two-term-ls.ts
@@ -19,7 +19,6 @@ import {
   serializeLatexLSTerm,
   serializeLSTerm,
 } from "./ls.js";
-import { serializeAtom } from "./serialize.js";
 
 const TwoTermLSDescriptor = buildTerm(
   buildTwoTerm(

--- a/packages/schema/src/species/atoms/two-term-ls.ts
+++ b/packages/schema/src/species/atoms/two-term-ls.ts
@@ -1,0 +1,57 @@
+// SPDX-FileCopyrightText: LXCat team
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { array, object, output } from "zod";
+import { makeComponent } from "../component.js";
+import { AtomComposition } from "../composition/atom.js";
+import { SpeciesBase } from "../composition/species-base.js";
+import { makeAtom } from "../generators.js";
+import {
+  buildTerm,
+  buildTwoTerm,
+  serializeShellConfig,
+  ShellEntry,
+} from "./common.js";
+import {
+  LSDescriptor,
+  LSTerm,
+  serializeLatexLSTerm,
+  serializeLSTerm,
+} from "./ls.js";
+import { serializeAtom } from "./serialize.js";
+
+const TwoTermLSDescriptor = buildTerm(
+  buildTwoTerm(
+    LSDescriptor,
+    object({ config: array(ShellEntry) }),
+  ),
+  LSTerm,
+);
+type TwoTermLSDescriptor = output<typeof TwoTermLSDescriptor>;
+
+const serializeTwoTermLS = (e: TwoTermLSDescriptor): string =>
+  `${serializeShellConfig(e.config.core.config)}{${
+    serializeLSTerm(e.config.core.term)
+  }}${serializeShellConfig(e.config.excited.config)} ${
+    serializeLSTerm(e.term)
+  }`;
+
+const serializeLatexTwoTermLS = (e: TwoTermLSDescriptor): string =>
+  `${serializeShellConfig(e.config.core.config)}\\left(${
+    serializeLatexLSTerm(e.config.core.term)
+  }\\right)${serializeShellConfig(e.config.excited.config)}\\;${
+    serializeLatexLSTerm(e.term)
+  }`;
+
+const TwoTermLSComponent = makeComponent(
+  TwoTermLSDescriptor,
+  serializeTwoTermLS,
+  serializeLatexTwoTermLS,
+);
+
+export const AtomLSTwoTerm = makeAtom(
+  "AtomLSTwoTerm",
+  SpeciesBase(AtomComposition),
+  TwoTermLSComponent,
+);

--- a/packages/schema/src/species/atoms/two-term-lsj.ts
+++ b/packages/schema/src/species/atoms/two-term-lsj.ts
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: LXCat team
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { array, object, output } from "zod";
+import { makeComponent } from "../component.js";
+import { AtomComposition } from "../composition/atom.js";
+import { SpeciesBase } from "../composition/species-base.js";
+import { makeAtom } from "../generators.js";
+import {
+  buildTerm,
+  buildTwoTerm,
+  serializeShellConfig,
+  ShellEntry,
+} from "./common.js";
+import { LSDescriptor, serializeLatexLSTerm, serializeLSTerm } from "./ls.js";
+import { LSJTerm, serializeLatexLSJTerm, serializeLSJTerm } from "./lsj.js";
+
+const TwoTermLSJDescriptor = buildTerm(
+  buildTwoTerm(
+    LSDescriptor,
+    object({ config: array(ShellEntry) }),
+  ),
+  LSJTerm,
+);
+type TwoTermLSJDescriptor = output<typeof TwoTermLSJDescriptor>;
+
+const serializeTwoTermLSJ = (e: TwoTermLSJDescriptor): string =>
+  `${serializeShellConfig(e.config.core.config)}{${
+    serializeLSTerm(e.config.core.term)
+  }}${serializeShellConfig(e.config.excited.config)} ${
+    serializeLSJTerm(e.term)
+  }`;
+
+const serializeLatexTwoTermLSJ = (e: TwoTermLSJDescriptor): string =>
+  `${serializeShellConfig(e.config.core.config)}\\left(${
+    serializeLatexLSTerm(e.config.core.term)
+  }\\right)${serializeShellConfig(e.config.excited.config)}\\;${
+    serializeLatexLSJTerm(e.term)
+  }`;
+
+const TwoTermLSJComponent = makeComponent(
+  TwoTermLSJDescriptor,
+  serializeTwoTermLSJ,
+  serializeLatexTwoTermLSJ,
+);
+
+export const AtomLSJTwoTerm = makeAtom(
+  "AtomLSJTwoTerm",
+  SpeciesBase(AtomComposition),
+  TwoTermLSJComponent,
+);

--- a/packages/schema/src/species/species.test.ts
+++ b/packages/schema/src/species/species.test.ts
@@ -40,6 +40,21 @@ describe("State serialization", () => {
     [
       "Helium LS ground",
       {
+        type: "AtomLSUncoupled",
+        composition: [["He", 1]],
+        charge: 0,
+        electronic: { config: [], term: { L: 0, S: 0, P: 1 } },
+      },
+      {
+        summary: "He{^1S}",
+        latex: "\\mathrm{He}\\left({}^{1}\\mathrm{S}\\right)",
+        composition: { summary: "He", latex: "\\mathrm{He}" },
+        electronic: { summary: "^1S", latex: "{}^{1}\\mathrm{S}" },
+      },
+    ],
+    [
+      "Helium LSJ ground",
+      {
         type: "AtomLS",
         composition: [["He", 1]],
         charge: 0,

--- a/packages/schema/src/species/species.test.ts
+++ b/packages/schema/src/species/species.test.ts
@@ -543,6 +543,67 @@ describe("State serialization", () => {
         },
       },
     ],
+    [
+      "Excited N atom (two-term LS coupling)",
+      {
+        type: "AtomLSTwoTerm",
+        composition: [["N", 1]],
+        charge: 0,
+        electronic: {
+          config: {
+            core: {
+              config: [{ n: 2, l: 1, occupance: 2 }],
+              term: { S: 1, L: 1, P: 1 },
+            },
+            excited: {
+              config: [{ n: 3, l: 0, occupance: 1 }],
+            },
+          },
+          term: { S: 1.5, L: 1, P: 1 },
+        },
+      },
+      {
+        composition: { summary: "N", latex: "\\mathrm{N}" },
+        summary: "N{2p^{2}{^3P}3s ^4P}",
+        latex:
+          "\\mathrm{N}\\left(2p^{2}\\left({}^{3}\\mathrm{P}\\right)3s\\;{}^{4}\\mathrm{P}\\right)",
+        electronic: {
+          summary: "2p^{2}{^3P}3s ^4P",
+          latex: "2p^{2}\\left({}^{3}\\mathrm{P}\\right)3s\\;{}^{4}\\mathrm{P}",
+        },
+      },
+    ],
+    [
+      "Excited N atom (two-term LSJ coupling)",
+      {
+        type: "AtomLSJTwoTerm",
+        composition: [["N", 1]],
+        charge: 0,
+        electronic: {
+          config: {
+            core: {
+              config: [{ n: 2, l: 1, occupance: 2 }],
+              term: { S: 1, L: 1, P: 1 },
+            },
+            excited: {
+              config: [{ n: 3, l: 0, occupance: 1 }],
+            },
+          },
+          term: { S: 1.5, L: 1, P: 1, J: 0.5 },
+        },
+      },
+      {
+        composition: { summary: "N", latex: "\\mathrm{N}" },
+        summary: "N{2p^{2}{^3P}3s ^4P_1/2}",
+        latex:
+          "\\mathrm{N}\\left(2p^{2}\\left({}^{3}\\mathrm{P}\\right)3s\\;{}^{4}\\mathrm{P}_{1/2}\\right)",
+        electronic: {
+          summary: "2p^{2}{^3P}3s ^4P_1/2",
+          latex:
+            "2p^{2}\\left({}^{3}\\mathrm{P}\\right)3s\\;{}^{4}\\mathrm{P}_{1/2}",
+        },
+      },
+    ],
   ];
 
   it.each(testCases)("%s", (_, input, summary) => {

--- a/packages/schema/src/test-data/LTPMixture.schema.json
+++ b/packages/schema/src/test-data/LTPMixture.schema.json
@@ -1476,6 +1476,536 @@
           "type": "object",
           "properties": {
             "type": {
+              "const": "AtomLSTwoTerm"
+            },
+            "composition": {
+              "type": "array",
+              "prefixItems": [
+                {
+                  "type": "array",
+                  "prefixItems": [
+                    {
+                      "$ref": "#/$defs/Element"
+                    },
+                    {
+                      "const": 1
+                    }
+                  ]
+                }
+              ]
+            },
+            "charge": {
+              "type": "integer",
+              "minimum": -9007199254740991,
+              "maximum": 9007199254740991
+            },
+            "electronic": {
+              "anyOf": [
+                {
+                  "description": "Singular",
+                  "type": "object",
+                  "properties": {
+                    "config": {
+                      "type": "object",
+                      "properties": {
+                        "core": {
+                          "type": "object",
+                          "properties": {
+                            "config": {
+                              "type": "array",
+                              "items": {
+                                "$ref": "#/$defs/ShellEntry"
+                              }
+                            },
+                            "term": {
+                              "type": "object",
+                              "properties": {
+                                "L": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "maximum": 9007199254740991
+                                },
+                                "S": {
+                                  "type": "number",
+                                  "minimum": 0,
+                                  "multipleOf": 0.5
+                                },
+                                "P": {
+                                  "anyOf": [
+                                    {
+                                      "const": -1
+                                    },
+                                    {
+                                      "const": 1
+                                    }
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "L",
+                                "S",
+                                "P"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "config",
+                            "term"
+                          ]
+                        },
+                        "excited": {
+                          "type": "object",
+                          "properties": {
+                            "config": {
+                              "type": "array",
+                              "items": {
+                                "$ref": "#/$defs/ShellEntry"
+                              }
+                            }
+                          },
+                          "required": [
+                            "config"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "core",
+                        "excited"
+                      ]
+                    },
+                    "term": {
+                      "type": "object",
+                      "properties": {
+                        "L": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "maximum": 9007199254740991
+                        },
+                        "S": {
+                          "type": "number",
+                          "minimum": 0,
+                          "multipleOf": 0.5
+                        },
+                        "P": {
+                          "anyOf": [
+                            {
+                              "const": -1
+                            },
+                            {
+                              "const": 1
+                            }
+                          ]
+                        }
+                      },
+                      "required": [
+                        "L",
+                        "S",
+                        "P"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "config",
+                    "term"
+                  ]
+                },
+                {
+                  "description": "Compound",
+                  "minItems": 2,
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "config": {
+                        "type": "object",
+                        "properties": {
+                          "core": {
+                            "type": "object",
+                            "properties": {
+                              "config": {
+                                "type": "array",
+                                "items": {
+                                  "$ref": "#/$defs/ShellEntry"
+                                }
+                              },
+                              "term": {
+                                "type": "object",
+                                "properties": {
+                                  "L": {
+                                    "type": "integer",
+                                    "minimum": 0,
+                                    "maximum": 9007199254740991
+                                  },
+                                  "S": {
+                                    "type": "number",
+                                    "minimum": 0,
+                                    "multipleOf": 0.5
+                                  },
+                                  "P": {
+                                    "anyOf": [
+                                      {
+                                        "const": -1
+                                      },
+                                      {
+                                        "const": 1
+                                      }
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "L",
+                                  "S",
+                                  "P"
+                                ]
+                              }
+                            },
+                            "required": [
+                              "config",
+                              "term"
+                            ]
+                          },
+                          "excited": {
+                            "type": "object",
+                            "properties": {
+                              "config": {
+                                "type": "array",
+                                "items": {
+                                  "$ref": "#/$defs/ShellEntry"
+                                }
+                              }
+                            },
+                            "required": [
+                              "config"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "core",
+                          "excited"
+                        ]
+                      },
+                      "term": {
+                        "type": "object",
+                        "properties": {
+                          "L": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 9007199254740991
+                          },
+                          "S": {
+                            "type": "number",
+                            "minimum": 0,
+                            "multipleOf": 0.5
+                          },
+                          "P": {
+                            "anyOf": [
+                              {
+                                "const": -1
+                              },
+                              {
+                                "const": 1
+                              }
+                            ]
+                          }
+                        },
+                        "required": [
+                          "L",
+                          "S",
+                          "P"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "config",
+                      "term"
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          "required": [
+            "type",
+            "composition",
+            "charge",
+            "electronic"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
+              "const": "AtomLSJTwoTerm"
+            },
+            "composition": {
+              "type": "array",
+              "prefixItems": [
+                {
+                  "type": "array",
+                  "prefixItems": [
+                    {
+                      "$ref": "#/$defs/Element"
+                    },
+                    {
+                      "const": 1
+                    }
+                  ]
+                }
+              ]
+            },
+            "charge": {
+              "type": "integer",
+              "minimum": -9007199254740991,
+              "maximum": 9007199254740991
+            },
+            "electronic": {
+              "anyOf": [
+                {
+                  "description": "Singular",
+                  "type": "object",
+                  "properties": {
+                    "config": {
+                      "type": "object",
+                      "properties": {
+                        "core": {
+                          "type": "object",
+                          "properties": {
+                            "config": {
+                              "type": "array",
+                              "items": {
+                                "$ref": "#/$defs/ShellEntry"
+                              }
+                            },
+                            "term": {
+                              "type": "object",
+                              "properties": {
+                                "L": {
+                                  "type": "integer",
+                                  "minimum": 0,
+                                  "maximum": 9007199254740991
+                                },
+                                "S": {
+                                  "type": "number",
+                                  "minimum": 0,
+                                  "multipleOf": 0.5
+                                },
+                                "P": {
+                                  "anyOf": [
+                                    {
+                                      "const": -1
+                                    },
+                                    {
+                                      "const": 1
+                                    }
+                                  ]
+                                }
+                              },
+                              "required": [
+                                "L",
+                                "S",
+                                "P"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "config",
+                            "term"
+                          ]
+                        },
+                        "excited": {
+                          "type": "object",
+                          "properties": {
+                            "config": {
+                              "type": "array",
+                              "items": {
+                                "$ref": "#/$defs/ShellEntry"
+                              }
+                            }
+                          },
+                          "required": [
+                            "config"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "core",
+                        "excited"
+                      ]
+                    },
+                    "term": {
+                      "type": "object",
+                      "properties": {
+                        "L": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "maximum": 9007199254740991
+                        },
+                        "S": {
+                          "type": "number",
+                          "minimum": 0,
+                          "multipleOf": 0.5
+                        },
+                        "P": {
+                          "anyOf": [
+                            {
+                              "const": -1
+                            },
+                            {
+                              "const": 1
+                            }
+                          ]
+                        },
+                        "J": {
+                          "type": "number",
+                          "minimum": 0,
+                          "multipleOf": 0.5
+                        }
+                      },
+                      "required": [
+                        "L",
+                        "S",
+                        "P",
+                        "J"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "config",
+                    "term"
+                  ]
+                },
+                {
+                  "description": "Compound",
+                  "minItems": 2,
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "config": {
+                        "type": "object",
+                        "properties": {
+                          "core": {
+                            "type": "object",
+                            "properties": {
+                              "config": {
+                                "type": "array",
+                                "items": {
+                                  "$ref": "#/$defs/ShellEntry"
+                                }
+                              },
+                              "term": {
+                                "type": "object",
+                                "properties": {
+                                  "L": {
+                                    "type": "integer",
+                                    "minimum": 0,
+                                    "maximum": 9007199254740991
+                                  },
+                                  "S": {
+                                    "type": "number",
+                                    "minimum": 0,
+                                    "multipleOf": 0.5
+                                  },
+                                  "P": {
+                                    "anyOf": [
+                                      {
+                                        "const": -1
+                                      },
+                                      {
+                                        "const": 1
+                                      }
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "L",
+                                  "S",
+                                  "P"
+                                ]
+                              }
+                            },
+                            "required": [
+                              "config",
+                              "term"
+                            ]
+                          },
+                          "excited": {
+                            "type": "object",
+                            "properties": {
+                              "config": {
+                                "type": "array",
+                                "items": {
+                                  "$ref": "#/$defs/ShellEntry"
+                                }
+                              }
+                            },
+                            "required": [
+                              "config"
+                            ]
+                          }
+                        },
+                        "required": [
+                          "core",
+                          "excited"
+                        ]
+                      },
+                      "term": {
+                        "type": "object",
+                        "properties": {
+                          "L": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 9007199254740991
+                          },
+                          "S": {
+                            "type": "number",
+                            "minimum": 0,
+                            "multipleOf": 0.5
+                          },
+                          "P": {
+                            "anyOf": [
+                              {
+                                "const": -1
+                              },
+                              {
+                                "const": 1
+                              }
+                            ]
+                          },
+                          "J": {
+                            "type": "number",
+                            "minimum": 0,
+                            "multipleOf": 0.5
+                          }
+                        },
+                        "required": [
+                          "L",
+                          "S",
+                          "P",
+                          "J"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "config",
+                      "term"
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          "required": [
+            "type",
+            "composition",
+            "charge",
+            "electronic"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
               "const": "AtomLS1"
             },
             "composition": {

--- a/packages/schema/src/test-data/LTPMixture.schema.json
+++ b/packages/schema/src/test-data/LTPMixture.schema.json
@@ -1194,6 +1194,141 @@
           "type": "object",
           "properties": {
             "type": {
+              "const": "AtomLSUncoupled"
+            },
+            "composition": {
+              "type": "array",
+              "prefixItems": [
+                {
+                  "type": "array",
+                  "prefixItems": [
+                    {
+                      "$ref": "#/$defs/Element"
+                    },
+                    {
+                      "const": 1
+                    }
+                  ]
+                }
+              ]
+            },
+            "charge": {
+              "type": "integer",
+              "minimum": -9007199254740991,
+              "maximum": 9007199254740991
+            },
+            "electronic": {
+              "anyOf": [
+                {
+                  "description": "Singular",
+                  "type": "object",
+                  "properties": {
+                    "config": {
+                      "type": "array",
+                      "items": {
+                        "$ref": "#/$defs/ShellEntry"
+                      }
+                    },
+                    "term": {
+                      "type": "object",
+                      "properties": {
+                        "L": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "maximum": 9007199254740991
+                        },
+                        "S": {
+                          "type": "number",
+                          "minimum": 0,
+                          "multipleOf": 0.5
+                        },
+                        "P": {
+                          "anyOf": [
+                            {
+                              "const": -1
+                            },
+                            {
+                              "const": 1
+                            }
+                          ]
+                        }
+                      },
+                      "required": [
+                        "L",
+                        "S",
+                        "P"
+                      ]
+                    }
+                  },
+                  "required": [
+                    "config",
+                    "term"
+                  ]
+                },
+                {
+                  "description": "Compound",
+                  "minItems": 2,
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "config": {
+                        "type": "array",
+                        "items": {
+                          "$ref": "#/$defs/ShellEntry"
+                        }
+                      },
+                      "term": {
+                        "type": "object",
+                        "properties": {
+                          "L": {
+                            "type": "integer",
+                            "minimum": 0,
+                            "maximum": 9007199254740991
+                          },
+                          "S": {
+                            "type": "number",
+                            "minimum": 0,
+                            "multipleOf": 0.5
+                          },
+                          "P": {
+                            "anyOf": [
+                              {
+                                "const": -1
+                              },
+                              {
+                                "const": 1
+                              }
+                            ]
+                          }
+                        },
+                        "required": [
+                          "L",
+                          "S",
+                          "P"
+                        ]
+                      }
+                    },
+                    "required": [
+                      "config",
+                      "term"
+                    ]
+                  }
+                }
+              ]
+            }
+          },
+          "required": [
+            "type",
+            "composition",
+            "charge",
+            "electronic"
+          ]
+        },
+        {
+          "type": "object",
+          "properties": {
+            "type": {
               "const": "AtomLS"
             },
             "composition": {


### PR DESCRIPTION
The `AtomLSUncoupled` type is used to describe states that do not specify hyperfine splitting. The other two types are useful for atoms that require a separate term for the coupling of the core electrons (e.g. for F and N). After the data migration is complete, the `AtomLSUncoupled` type will be renamed to `AtomLS`, and the former `AtomLS` type will be renamed to `AtomLSJ`.`