### PR TITLE
Lift `minLength` restriction on process comments

### DIFF
--- a/packages/schema/src/common/util.ts
+++ b/packages/schema/src/common/util.ts
@@ -2,11 +2,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { array, tuple, union, ZodTypeAny } from "zod";
+import { array, tuple, union, ZodType } from "zod";
 
-export const Pair = <InnerType extends ZodTypeAny>(InnerType: InnerType) =>
+export const Pair = <InnerType extends ZodType>(InnerType: InnerType) =>
   tuple([InnerType, InnerType]);
 
-export const OneOrMultiple = <InnerType extends ZodTypeAny>(
+export const OneOrMultiple = <InnerType extends ZodType>(
   InnerType: InnerType,
 ) => union([InnerType, array(InnerType).min(2)]);

--- a/packages/schema/src/process/cross-section/cross-section.ts
+++ b/packages/schema/src/process/cross-section/cross-section.ts
@@ -2,12 +2,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { number, object, TypeOf, ZodType, ZodTypeAny } from "zod";
+import { number, object, TypeOf, ZodType } from "zod";
 import { ProcessInfoBase } from "../process-info-base.js";
 import { CrossSectionData } from "./data-types.js";
 import { CrossSectionParameters } from "./parameters.js";
 
-export const CrossSectionInfo = <ReferenceType extends ZodTypeAny>(
+export const CrossSectionInfo = <ReferenceType extends ZodType>(
   ReferenceType: ReferenceType,
 ) =>
   ProcessInfoBase("CrossSection", CrossSectionData, ReferenceType).merge(
@@ -18,7 +18,7 @@ export const CrossSectionInfo = <ReferenceType extends ZodTypeAny>(
     }),
   );
 
-type CrossSectionInfoType<ReferenceType extends ZodTypeAny> = ReturnType<
+type CrossSectionInfoType<ReferenceType extends ZodType> = ReturnType<
   typeof CrossSectionInfo<ReferenceType>
 >;
 

--- a/packages/schema/src/process/edited-process.ts
+++ b/packages/schema/src/process/edited-process.ts
@@ -2,20 +2,20 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { output, ZodType, ZodTypeAny } from "zod";
+import { output, ZodType } from "zod";
 import { PartialKeyed } from "../partial-keyed.js";
 import { ProcessInfo } from "./process-info.js";
 import { Process } from "./process.js";
 
 export const EditedProcess = <
-  StateType extends ZodTypeAny,
-  ReferenceType extends ZodTypeAny,
+  StateType extends ZodType,
+  ReferenceType extends ZodType,
 >(StateType: StateType, ReferenceType: ReferenceType) =>
   Process(StateType, PartialKeyed(ProcessInfo(ReferenceType)));
 
 type EditedProcessType<
-  StateType extends ZodTypeAny,
-  ReferenceType extends ZodTypeAny,
+  StateType extends ZodType,
+  ReferenceType extends ZodType,
 > = ReturnType<typeof EditedProcess<StateType, ReferenceType>>;
 
 export type EditedProcess<StateType, ReferenceType> = output<

--- a/packages/schema/src/process/new-process.ts
+++ b/packages/schema/src/process/new-process.ts
@@ -2,19 +2,19 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { output, ZodType, ZodTypeAny } from "zod";
+import { output, ZodType } from "zod";
 import { ProcessInfo } from "./process-info.js";
 import { Process } from "./process.js";
 
 export const NewProcess = <
-  StateType extends ZodTypeAny,
-  ReferenceType extends ZodTypeAny,
+  StateType extends ZodType,
+  ReferenceType extends ZodType,
 >(StateType: StateType, ReferenceType: ReferenceType) =>
   Process(StateType, ProcessInfo(ReferenceType));
 
 type NewProcessType<
-  StateType extends ZodTypeAny,
-  ReferenceType extends ZodTypeAny,
+  StateType extends ZodType,
+  ReferenceType extends ZodType,
 > = ReturnType<typeof NewProcess<StateType, ReferenceType>>;
 
 export type NewProcess<StateType, ReferenceType> = output<

--- a/packages/schema/src/process/process-info-base.ts
+++ b/packages/schema/src/process/process-info-base.ts
@@ -15,7 +15,7 @@ export const ProcessInfoBase = <
 ) =>
   object({
     type: literal(type),
-    comments: array(string().min(1)).optional(),
+    comments: array(string()).optional(),
     references: array(referenceType),
     data: dataType,
   });

--- a/packages/schema/src/process/process-info-base.ts
+++ b/packages/schema/src/process/process-info-base.ts
@@ -2,12 +2,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { array, literal, object, string, ZodTypeAny } from "zod";
+import { array, literal, object, string, ZodType } from "zod";
 
 export const ProcessInfoBase = <
   TypeTag extends string,
-  DataType extends ZodTypeAny,
-  ReferenceType extends ZodTypeAny,
+  DataType extends ZodType,
+  ReferenceType extends ZodType,
 >(
   type: TypeTag,
   dataType: DataType,

--- a/packages/schema/src/process/process-info.ts
+++ b/packages/schema/src/process/process-info.ts
@@ -2,12 +2,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { ZodTypeAny } from "zod";
+import { ZodType } from "zod";
 import { CrossSectionInfo } from "./cross-section/cross-section.js";
 
 // TODO: This object should be a discriminated union over all the possible
 //       process info objects (cross sections, potentials, rate coefficients,
 //       etc.).
-export const ProcessInfo = <ReferenceType extends ZodTypeAny>(
+export const ProcessInfo = <ReferenceType extends ZodType>(
   ReferenceType: ReferenceType,
 ) => CrossSectionInfo(ReferenceType);

--- a/packages/schema/src/process/process.ts
+++ b/packages/schema/src/process/process.ts
@@ -2,12 +2,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { array, object, ZodTypeAny } from "zod";
+import { array, object, ZodType } from "zod";
 import { Reaction } from "./reaction/index.js";
 
 export const Process = <
-  StateType extends ZodTypeAny,
-  ProcessInfoType extends ZodTypeAny,
+  StateType extends ZodType,
+  ProcessInfoType extends ZodType,
 >(StateType: StateType, ProcessInfoType: ProcessInfoType) =>
   object({
     reaction: Reaction(StateType),

--- a/packages/schema/src/process/reaction/index.ts
+++ b/packages/schema/src/process/reaction/index.ts
@@ -2,22 +2,14 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import {
-  array,
-  boolean,
-  number,
-  object,
-  TypeOf,
-  ZodType,
-  ZodTypeAny,
-} from "zod";
+import { array, boolean, number, object, TypeOf, ZodType } from "zod";
 import { ReactionTypeTag } from "./type-tags.js";
 
-export const ReactionEntry = <StateType extends ZodTypeAny>(
+export const ReactionEntry = <StateType extends ZodType>(
   StateType: StateType,
 ) => object({ count: number().int().positive(), state: StateType });
 
-type ReactionEntryType<StateType extends ZodTypeAny> = ReturnType<
+type ReactionEntryType<StateType extends ZodType> = ReturnType<
   typeof ReactionEntry<StateType>
 >;
 
@@ -25,7 +17,7 @@ export type ReactionEntry<StateType> = TypeOf<
   ReactionEntryType<ZodType<StateType>>
 >;
 
-export const Reaction = <StateType extends ZodTypeAny>(
+export const Reaction = <StateType extends ZodType>(
   StateType: StateType,
 ) =>
   object({
@@ -35,7 +27,7 @@ export const Reaction = <StateType extends ZodTypeAny>(
     typeTags: array(ReactionTypeTag),
   });
 
-type ReactionType<StateType extends ZodTypeAny> = ReturnType<
+type ReactionType<StateType extends ZodType> = ReturnType<
   typeof Reaction<StateType>
 >;
 

--- a/packages/schema/src/process/versioned-process.ts
+++ b/packages/schema/src/process/versioned-process.ts
@@ -2,20 +2,20 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { output, ZodType, ZodTypeAny } from "zod";
+import { output, ZodType } from "zod";
 import { versioned } from "../versioned.js";
 import { ProcessInfo } from "./process-info.js";
 import { Process } from "./process.js";
 
 export const VersionedProcess = <
-  StateType extends ZodTypeAny,
-  ReferenceType extends ZodTypeAny,
+  StateType extends ZodType,
+  ReferenceType extends ZodType,
 >(StateType: StateType, ReferenceType: ReferenceType) =>
   Process(StateType, versioned(ProcessInfo(ReferenceType)));
 
 type VersionedProcessType<
-  StateType extends ZodTypeAny,
-  ReferenceType extends ZodTypeAny,
+  StateType extends ZodType,
+  ReferenceType extends ZodType,
 > = ReturnType<typeof VersionedProcess<StateType, ReferenceType>>;
 
 export type VersionedProcess<StateType, ReferenceType> = output<

--- a/packages/schema/src/set-header.ts
+++ b/packages/schema/src/set-header.ts
@@ -2,9 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { boolean, object, output, string, ZodType, ZodTypeAny } from "zod";
+import { boolean, object, output, string, ZodType } from "zod";
 
-export const SetHeader = <ContributorType extends ZodTypeAny>(
+export const SetHeader = <ContributorType extends ZodType>(
   contributor: ContributorType,
 ) =>
   object({
@@ -17,7 +17,7 @@ export const SetHeader = <ContributorType extends ZodTypeAny>(
     complete: boolean(),
   });
 
-type SetHeaderInfoType<ReferenceType extends ZodTypeAny> = ReturnType<
+type SetHeaderInfoType<ReferenceType extends ZodType> = ReturnType<
   typeof SetHeader<ReferenceType>
 >;
 

--- a/packages/schema/src/species/atoms/common.ts
+++ b/packages/schema/src/species/atoms/common.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { globalRegistry, number, object, TypeOf, ZodTypeAny } from "zod";
+import { globalRegistry, number, object, TypeOf, ZodType } from "zod";
 import { electronicOrbital } from "../common.js";
 
 /**
@@ -28,8 +28,8 @@ export const TotalAngularSpecifier = object({
  * @returns A zod object representing an atomic state configuration.
  */
 export const buildTerm = <
-  EConfig extends ZodTypeAny,
-  TermSymbol extends ZodTypeAny,
+  EConfig extends ZodType,
+  TermSymbol extends ZodType,
 >(electronConfig: EConfig, term: TermSymbol) =>
   object({ config: electronConfig, term });
 
@@ -43,8 +43,8 @@ export const buildTerm = <
  *          e.g. LS1 and J1L2 coupling).
  */
 export const buildTwoTerm = <
-  Core extends ZodTypeAny,
-  Excited extends ZodTypeAny,
+  Core extends ZodType,
+  Excited extends ZodType,
 >(core: Core, excited: Excited) => object({ core, excited });
 
 export const ShellEntry = object({

--- a/packages/schema/src/test-data/LTPMixture.schema.json
+++ b/packages/schema/src/test-data/LTPMixture.schema.json
@@ -188,8 +188,7 @@
                 "comments": {
                   "type": "array",
                   "items": {
-                    "type": "string",
-                    "minLength": 1
+                    "type": "string"
                   }
                 },
                 "references": {


### PR DESCRIPTION
Some QUANTEMOL datasets contain empty comment line. We will preserve those for now, but that requires the `minLength` restriction on process comments to be lifted. This PR also cleans up usage of the now deprecated `ZodTypeAny`.