### PR TITLE
Allow `https://loki-suite.github.io` to access the LXCat api

### DIFF
--- a/app/src/app/api/middleware/cors.ts
+++ b/app/src/app/api/middleware/cors.ts
@@ -17,7 +17,7 @@ export type CORSOptions = {
 };
 
 const DEFAULTS: CORSOptions = {
-  allowedOrigins: [/http:\/\/localhost:\d+/],
+  allowedOrigins: [/http:\/\/localhost:\d+/, /https:\/\/loki-suite.github.io/],
   allowedMethods: ["GET", "HEAD"],
   allowedHeaders: ["Authorization", "Content-Type"],
   preflightStatusCode: 204,


### PR DESCRIPTION
This PR whitelists https://loki-suite.github.io in the CORS filter.