### PR TITLE
Put the set selection component in a scroll area

### DIFF
--- a/app/src/shared/swr-reaction-picker-shell.tsx
+++ b/app/src/shared/swr-reaction-picker-shell.tsx
@@ -9,6 +9,7 @@ import {
   Group,
   MultiSelect,
   MultiSelectProps,
+  ScrollArea,
   Stack,
 } from "@mantine/core";
 import { CSSetFilter, CSSetFilterProps } from "./cs-set-filter";
@@ -63,7 +64,9 @@ export const SWRReactionPickerShell = ({
         />
       </Stack>
       <Fieldset legend="Set selection">
-        <CSSetFilter {...sets} />
+        <ScrollArea h={128} type="auto" offsetScrollbars>
+          <CSSetFilter {...sets} />
+        </ScrollArea>
       </Fieldset>
     </Group>
   );


### PR DESCRIPTION
With the current number of contributors on <https://demo.lxcat.net>, the set selection component on <https://demo.lxcat.net/scat-cs> became quite unwieldy. This PR introduces a `ScrollArea` to limit the size of the component.