### PR TITLE
Increase database setup timeout for tests

### DIFF
--- a/packages/database/src/test/global-setup.ts
+++ b/packages/database/src/test/global-setup.ts
@@ -5,4 +5,4 @@
 import { beforeAll } from "bun:test";
 import { startDbContainer } from "../testutils.js";
 
-beforeAll(startDbContainer);
+beforeAll(startDbContainer, { timeout: 60000 });


### PR DESCRIPTION
Sometimes the database tests would timeout before succesfully spinning up the ArangoDB container.