### PR TITLE
Ignore the `test-results` directory

### DIFF
--- a/app/.gitignore
+++ b/app/.gitignore
@@ -54,6 +54,7 @@ build-storybook.log
 
 # test
 junit-*.xml
+test-results
 
 # vscode
 .vscode


### PR DESCRIPTION
Playwright now automatically creates this directory. It should not be pushed to remote.