### PR TITLE
Fix coverage report generation for `@lxcat/database` in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -136,7 +136,7 @@ jobs:
     - name: Install dependencies
       run: bun install
     - name: Test @lxcat/database
-      run: (cd packages/database && bun test --timeout 120000 --coverage --coverage-report=lcov)
+      run: (cd packages/database && bun test --timeout 120000 --coverage --coverage-reporter=lcov)
     - name: Upload coverage report to Codecov
       uses: codecov/codecov-action@v7
       with:


### PR DESCRIPTION
Fixes typo in CI `bun test` invocation for to the `@lxcat/database` package. This typo would cause the coverage report to not be generated in `lcov` format, and thus not be detected by the codecov action.