### PR TITLE
Fix coverage for end-to-end tests in turbopack builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,12 +66,13 @@ jobs:
     - name: Build packages
       # TODO: Switch back to turborepo build once we do not have to rely on
       # webpack for coverage reporting.
-      # run: bun run build --env-mode=loose
-      run: |
-        (cd packages/schema && bun run build)
-        (cd packages/database && bun run build)
-        (cd packages/converter && bun run build)
-        (cd app && bun run build --webpack)
+      run: NEXT_ENABLE_COVERAGE=1 bun run build --env-mode=loose
+      # TODO: Otherwise do this
+      # run: |
+      #   (cd packages/schema && bun run build)
+      #   (cd packages/database && bun run build)
+      #   (cd packages/converter && bun run build)
+      #   (cd app && NEXT_ENABLE_COVERAGE=1 bun run build --turbopack)
     # TODO: re-enable lint when TypeScript 7.1 is released.
     # - name: Lint
     #   run: bun run lint

--- a/app/.nycrc.json
+++ b/app/.nycrc.json
@@ -1,6 +1,6 @@
 {
   "include": [
-    "src/**/*.tsx",
-    "src/**/*.ts"
+    "app/src/**/*.tsx",
+    "app/src/**/*.ts"
   ]
 }

--- a/app/e2e/author-css.spec.ts
+++ b/app/e2e/author-css.spec.ts
@@ -128,22 +128,10 @@ test.describe("/author/set/add", () => {
 
       await page.locator("button:has-text(\"Submit\")").click();
 
-      // TODO: This branch is here as we do a webpack build in CI for
-      //       coverage support (I cannot get end-to-end coverage working with
-      //       turbopack). However, there is a bug in webpack (presumably) that
-      //       causes it to not bundle zod error messages correctly, resulting
-      //       in more vague errors.
-      if (process.env.CI) {
-        const warning = page.getByText(
-          "Invalid input",
-        );
-        await expect(warning).toHaveCount(3);
-      } else {
-        const warning = page.getByText(
-          "Too small: expected string to have >=1 characters",
-        );
-        await expect(warning).toHaveCount(3);
-      }
+      const warning = page.getByText(
+        "Too small: expected string to have >=1 characters",
+      );
+      await expect(warning).toHaveCount(3);
     });
   });
 

--- a/app/next.config.js
+++ b/app/next.config.js
@@ -16,7 +16,7 @@ const nextConfig = {
 
   experimental: {
     optimizePackageImports: ["@mantine/core", "@mantine/hooks"],
-    swcPlugins: process.env.CI && [
+    swcPlugins: process.env.NEXT_ENABLE_COVERAGE && [
       ["swc-plugin-coverage-instrument", {}],
     ],
     useTypeScriptCli: true
@@ -35,7 +35,7 @@ const nextConfig = {
   // that the webpack customization below is intentional and not needed here.
   turbopack: {},
 
-  productionBrowserSourceMaps: process.env.CI !== undefined,
+  productionBrowserSourceMaps: !!process.env.NEXT_ENABLE_COVERAGE,
 
   webpack: (config) => {
     config.resolve.alias["@"] = path.resolve(import.meta.dirname, "src");

--- a/app/playwright.config.ts
+++ b/app/playwright.config.ts
@@ -16,7 +16,7 @@ const config: PlaywrightTestConfig = {
   globalSetup: "./e2e/global-setup",
   // globalTimeout: 5 * 60 * 1000, // Wait for 5 minutes to spinup oidc server and database
   webServer: {
-    command: `bun ${process.env.CI ? "coverage:start" : "start"} --port 8001`,
+    command: "bun coverage:start --port 8001",
     port: 8001,
     // timeout: 2 * 60 * 1000, // Wait for 2 minutes to spinup app dev server
     reuseExistingServer: !process.env.CI,


### PR DESCRIPTION
This enables generation of code coverage reports for end-to-end tests in builds that use turbopack. This means that we can now use turbopack in CI, which greatly improves build performance, removes duct-tape-esque patches to maintain compatible with webpack, and also fixes bundling errors such as the one now bugging #3070.